### PR TITLE
Let item reader to drive item indexes

### DIFF
--- a/src/batch/src/Job/Item/ItemJob.php
+++ b/src/batch/src/Job/Item/ItemJob.php
@@ -77,9 +77,7 @@ class ItemJob extends AbstractJob
 
         $writeCount = 0;
         $itemsToWrite = [];
-        $lineNumber = 1;
-        foreach ($this->reader->read() as $readItem) {
-            $lineNumber++;
+        foreach ($this->reader->read() as $readIndex => $readItem) {
             $summary->increment('read');
 
             try {
@@ -87,7 +85,7 @@ class ItemJob extends AbstractJob
             } catch (InvalidItemException $exception) {
                 $summary->increment('invalid');
                 $jobExecution->addWarning(
-                    new Warning($exception->getMessage(), $exception->getParameters(), ['line_number' => $lineNumber])
+                    new Warning($exception->getMessage(), $exception->getParameters(), ['itemIndex' => $readIndex])
                 );
 
                 continue;

--- a/src/batch/src/Job/Item/Reader/IndexWithReader.php
+++ b/src/batch/src/Job/Item/Reader/IndexWithReader.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Job\Item\Reader;
+
+use Yokai\Batch\Job\Item\ItemReaderInterface;
+
+final class IndexWithReader implements ItemReaderInterface
+{
+    private ItemReaderInterface $reader;
+
+    /**
+     * @var callable
+     */
+    private $getIndex;
+
+    public function __construct(ItemReaderInterface $reader, callable $getIndex)
+    {
+        $this->reader = $reader;
+        $this->getIndex = $getIndex;
+    }
+
+    public static function withArrayKey(ItemReaderInterface $reader, string $key): self
+    {
+        return new self($reader, fn(array $item) => $item[$key]);
+    }
+
+    public static function withProperty(ItemReaderInterface $reader, string $property): self
+    {
+        return new self($reader, fn(object $item) => $item->$property);
+    }
+
+    public static function withGetter(ItemReaderInterface $reader, string $getter): self
+    {
+        return new self($reader, fn(object $item) => $item->$getter());
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function read(): iterable
+    {
+        foreach ($this->reader->read() as $item) {
+            yield ($this->getIndex)($item) => $item;
+        }
+    }
+}

--- a/src/batch/src/Job/Item/Reader/IndexWithReader.php
+++ b/src/batch/src/Job/Item/Reader/IndexWithReader.php
@@ -37,16 +37,34 @@ final class IndexWithReader implements
         $this->extractItemIndex = $extractItemIndex;
     }
 
+    /**
+     * Uses item array value as the item index.
+     *
+     * Example, IndexWithReader::withArrayKey(..., 'name')
+     * will use 'name' array index of each read item as the item index.
+     */
     public static function withArrayKey(ItemReaderInterface $reader, string $key): self
     {
         return new self($reader, fn(array $item) => $item[$key]);
     }
 
+    /**
+     * Uses object property value as the item index.
+     *
+     * Example, IndexWithReader::withProperty(..., 'name')
+     * will use 'name' object property of each read item as the item index.
+     */
     public static function withProperty(ItemReaderInterface $reader, string $property): self
     {
         return new self($reader, fn(object $item) => $item->$property);
     }
 
+    /**
+     * Uses object method return value as the item index.
+     *
+     * Example, IndexWithReader::withProperty(..., 'getName')
+     * will call 'getName()' method of each read item and uses the result as the item index.
+     */
     public static function withGetter(ItemReaderInterface $reader, string $getter): self
     {
         return new self($reader, fn(object $item) => $item->$getter());

--- a/src/batch/src/Job/Item/Reader/IndexWithReader.php
+++ b/src/batch/src/Job/Item/Reader/IndexWithReader.php
@@ -4,21 +4,25 @@ declare(strict_types=1);
 
 namespace Yokai\Batch\Job\Item\Reader;
 
+use Closure;
 use Yokai\Batch\Job\Item\ItemReaderInterface;
 
+/**
+ * An {@see ItemReaderInterface} that decorates another {@see ItemReaderInterface}
+ * and extract item index of each item using a {@see Closure}.
+ *
+ * Provided {@see Closure} must accept a single argument (the read item)
+ * and must return a value (preferably unique) that will be item index.
+ */
 final class IndexWithReader implements ItemReaderInterface
 {
     private ItemReaderInterface $reader;
+    private Closure $extractItemIndex;
 
-    /**
-     * @var callable
-     */
-    private $getIndex;
-
-    public function __construct(ItemReaderInterface $reader, callable $getIndex)
+    public function __construct(ItemReaderInterface $reader, Closure $extractItemIndex)
     {
         $this->reader = $reader;
-        $this->getIndex = $getIndex;
+        $this->extractItemIndex = $extractItemIndex;
     }
 
     public static function withArrayKey(ItemReaderInterface $reader, string $key): self
@@ -42,7 +46,7 @@ final class IndexWithReader implements ItemReaderInterface
     public function read(): iterable
     {
         foreach ($this->reader->read() as $item) {
-            yield ($this->getIndex)($item) => $item;
+            yield ($this->extractItemIndex)($item) => $item;
         }
     }
 }

--- a/src/batch/tests/Job/Item/ItemJobTest.php
+++ b/src/batch/tests/Job/Item/ItemJobTest.php
@@ -86,6 +86,14 @@ class ItemJobTest extends TestCase
         self::assertSame(3, $jobExecution->getSummary()->get('invalid'), '3 items were invalid');
         self::assertSame(9, $jobExecution->getSummary()->get('write'), '9 items were write');
 
+        $warnings = $jobExecution->getWarnings();
+        self::assertCount(3, $warnings);
+        foreach ([[0, 9, 10], [1, 10, 11], [2, 11, 12]] as [$warningIdx, $itemIdx, $paramValue]) {
+            self::assertSame('Item is greater than 9 got {value}', $warnings[$warningIdx]->getMessage());
+            self::assertSame(['{value}' => $paramValue], $warnings[$warningIdx]->getParameters());
+            self::assertSame(['itemIndex' => $itemIdx], $warnings[$warningIdx]->getContext());
+        }
+
         $expectedLogs = <<<LOGS
 reader::setJobExecution
 reader::setJobParameters

--- a/src/batch/tests/Job/Item/Reader/IndexWithReaderTest.php
+++ b/src/batch/tests/Job/Item/Reader/IndexWithReaderTest.php
@@ -56,5 +56,13 @@ class IndexWithReaderTest extends TestCase
             ),
             [3 => $three, 6 => $six],
         ];
+
+        yield 'Index with arbitrary closure' => [
+            new IndexWithReader(
+                new StaticIterableReader([1, 2, 3]),
+                fn(int $value) => $value * $value
+            ),
+            [1 => 1, 4 => 2, 9 => 3],
+        ];
     }
 }

--- a/src/batch/tests/Job/Item/Reader/IndexWithReaderTest.php
+++ b/src/batch/tests/Job/Item/Reader/IndexWithReaderTest.php
@@ -9,6 +9,7 @@ use Generator;
 use PHPUnit\Framework\TestCase;
 use Yokai\Batch\Job\Item\Reader\IndexWithReader;
 use Yokai\Batch\Job\Item\Reader\StaticIterableReader;
+use Yokai\Batch\JobExecution;
 
 class IndexWithReaderTest extends TestCase
 {
@@ -17,10 +18,15 @@ class IndexWithReaderTest extends TestCase
      */
     public function test(IndexWithReader $reader, array $expected): void
     {
+        $reader->setJobExecution(JobExecution::createRoot('123456', 'testing'));
+        $reader->initialize();
+
         $actual = [];
         foreach ($reader->read() as $index => $item) {
             $actual[$index] = $item;
         }
+
+        $reader->flush();
 
         self::assertSame($expected, $actual);
     }

--- a/src/batch/tests/Job/Item/Reader/IndexWithReaderTest.php
+++ b/src/batch/tests/Job/Item/Reader/IndexWithReaderTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Tests\Job\Item\Reader;
+
+use ArrayIterator;
+use Generator;
+use PHPUnit\Framework\TestCase;
+use Yokai\Batch\Job\Item\Reader\IndexWithReader;
+use Yokai\Batch\Job\Item\Reader\StaticIterableReader;
+
+class IndexWithReaderTest extends TestCase
+{
+    /**
+     * @dataProvider provider
+     */
+    public function test(IndexWithReader $reader, array $expected): void
+    {
+        $actual = [];
+        foreach ($reader->read() as $index => $item) {
+            $actual[$index] = $item;
+        }
+
+        self::assertSame($expected, $actual);
+    }
+
+    public function provider(): Generator
+    {
+        $john = ['name' => 'John', 'location' => 'Washington'];
+        $marie = ['name' => 'Marie', 'location' => 'London'];
+        yield 'Index with array key' => [
+            IndexWithReader::withArrayKey(
+                new StaticIterableReader([$john, $marie]),
+                'name'
+            ),
+            ['John' => $john, 'Marie' => $marie],
+        ];
+
+        $john = (object)$john;
+        $marie = (object)$marie;
+        yield 'Index with object property' => [
+            IndexWithReader::withProperty(
+                new StaticIterableReader([$john, $marie]),
+                'name'
+            ),
+            ['John' => $john, 'Marie' => $marie],
+        ];
+
+        $three = new ArrayIterator([1, 2, 3]);
+        $six = new ArrayIterator([1, 2, 3, 4, 5, 6]);
+        yield 'Index with object method' => [
+            IndexWithReader::withGetter(
+                new StaticIterableReader([$three, $six]),
+                'count'
+            ),
+            [3 => $three, 6 => $six],
+        ];
+    }
+}

--- a/src/batch/tests/Job/Item/Reader/IndexWithReaderTest.php
+++ b/src/batch/tests/Job/Item/Reader/IndexWithReaderTest.php
@@ -16,8 +16,10 @@ class IndexWithReaderTest extends TestCase
     /**
      * @dataProvider provider
      */
-    public function test(IndexWithReader $reader, array $expected): void
+    public function test(callable $factory, array $expected): void
     {
+        /** @var IndexWithReader $reader */
+        $reader = $factory();
         $reader->setJobExecution(JobExecution::createRoot('123456', 'testing'));
         $reader->initialize();
 
@@ -36,7 +38,7 @@ class IndexWithReaderTest extends TestCase
         $john = ['name' => 'John', 'location' => 'Washington'];
         $marie = ['name' => 'Marie', 'location' => 'London'];
         yield 'Index with array key' => [
-            IndexWithReader::withArrayKey(
+            fn() => IndexWithReader::withArrayKey(
                 new StaticIterableReader([$john, $marie]),
                 'name'
             ),
@@ -46,7 +48,7 @@ class IndexWithReaderTest extends TestCase
         $john = (object)$john;
         $marie = (object)$marie;
         yield 'Index with object property' => [
-            IndexWithReader::withProperty(
+            fn() => IndexWithReader::withProperty(
                 new StaticIterableReader([$john, $marie]),
                 'name'
             ),
@@ -56,7 +58,7 @@ class IndexWithReaderTest extends TestCase
         $three = new ArrayIterator([1, 2, 3]);
         $six = new ArrayIterator([1, 2, 3, 4, 5, 6]);
         yield 'Index with object method' => [
-            IndexWithReader::withGetter(
+            fn() => IndexWithReader::withGetter(
                 new StaticIterableReader([$three, $six]),
                 'count'
             ),
@@ -64,7 +66,7 @@ class IndexWithReaderTest extends TestCase
         ];
 
         yield 'Index with arbitrary closure' => [
-            new IndexWithReader(
+            fn() => new IndexWithReader(
                 new StaticIterableReader([1, 2, 3]),
                 fn(int $value) => $value * $value
             ),


### PR DESCRIPTION
So far, library was using an "auto incremented" index to identify an item in the batch.

With this change, reader is allowed to determine what should be the item id.

If nothing is done, we will end to an auto-incremented integer, starting to 0.

This PR also introduce a reader decorator able to extract id from data read.