### PR TITLE
Introduce writer that writes to the JobExecution Summary

### DIFF
--- a/src/batch/src/Job/Item/Writer/SummaryWriter.php
+++ b/src/batch/src/Job/Item/Writer/SummaryWriter.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Job\Item\Writer;
+
+use Yokai\Batch\Job\Item\ItemWriterInterface;
+use Yokai\Batch\Job\JobExecutionAwareInterface;
+use Yokai\Batch\Job\JobExecutionAwareTrait;
+use Yokai\Batch\Job\Parameters\JobParameterAccessorInterface;
+use Yokai\Batch\JobExecution;
+use Yokai\Batch\Summary;
+
+/**
+ * An {@see ItemWriterInterface} that writes all item to the {@see JobExecution}'s {@see Summary}.
+ */
+final class SummaryWriter implements ItemWriterInterface, JobExecutionAwareInterface
+{
+    use JobExecutionAwareTrait;
+
+    private JobParameterAccessorInterface $index;
+
+    public function __construct(JobParameterAccessorInterface $index)
+    {
+        $this->index = $index;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function write(iterable $items): void
+    {
+        $key = $this->index->get($this->jobExecution);
+        foreach ($items as $item) {
+            $this->jobExecution->getSummary()->append($key, $item);
+        }
+    }
+}

--- a/src/batch/src/Summary.php
+++ b/src/batch/src/Summary.php
@@ -54,6 +54,16 @@ final class Summary implements
     }
 
     /**
+     * @param string $key
+     * @param mixed  $value
+     */
+    public function append(string $key, $value): void
+    {
+        $this->values[$key] = $this->values[$key] ?? [];
+        $this->values[$key][] = $value;
+    }
+
+    /**
      * @return mixed
      */
     public function get(string $key)

--- a/src/batch/tests/Job/Item/Writer/SummaryWriterTest.php
+++ b/src/batch/tests/Job/Item/Writer/SummaryWriterTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Tests\Job\Item\Writer;
+
+use Yokai\Batch\Job\Item\Writer\SummaryWriter;
+use PHPUnit\Framework\TestCase;
+use Yokai\Batch\Job\Parameters\StaticValueParameterAccessor;
+use Yokai\Batch\JobExecution;
+
+class SummaryWriterTest extends TestCase
+{
+    public function test(): void
+    {
+        $writer = new SummaryWriter(new StaticValueParameterAccessor('target'));
+        $writer->setJobExecution($jobExecution = JobExecution::createRoot('123456', 'testing'));
+
+        self::assertSame(null, $jobExecution->getSummary()->get('target'));
+        $writer->write(['One']);
+        self::assertSame(['One'], $jobExecution->getSummary()->get('target'));
+        $writer->write(['Two', 'Three']);
+        self::assertSame(['One', 'Two', 'Three'], $jobExecution->getSummary()->get('target'));
+    }
+}


### PR DESCRIPTION
This writer will be useful for debug purpose (combined with a ChainWriter and an optional registering), or to be used combined with a reader that will be able to read from summary of an other job execution (#34).