### PR TITLE
Add PhpDoc to most classes and updated documentation

### DIFF
--- a/src/batch-box-spout/src/FlatFileReader.php
+++ b/src/batch-box-spout/src/FlatFileReader.php
@@ -41,9 +41,6 @@ final class FlatFileReader implements
 
     private const TYPES = [Type::CSV, Type::XLSX, Type::ODS];
 
-    /**
-     * @var string
-     */
     private string $type;
 
     /**
@@ -51,9 +48,6 @@ final class FlatFileReader implements
      */
     private array $options;
 
-    /**
-     * @var string
-     */
     private string $headersMode;
 
     /**
@@ -61,9 +55,6 @@ final class FlatFileReader implements
      */
     private ?array $headers;
 
-    /**
-     * @var JobParameterAccessorInterface
-     */
     private JobParameterAccessorInterface $filePath;
 
     /**

--- a/src/batch-doctrine-dbal/src/DoctrineDBALInsertWriter.php
+++ b/src/batch-doctrine-dbal/src/DoctrineDBALInsertWriter.php
@@ -8,6 +8,11 @@ use Doctrine\DBAL\Connection;
 use Doctrine\Persistence\ConnectionRegistry;
 use Yokai\Batch\Job\Item\ItemWriterInterface;
 
+/**
+ * This {@see ItemWriterInterface} will insert all items to a single table,
+ * via a Doctrine {@see Connection}.
+ * All items must be arrays.
+ */
 final class DoctrineDBALInsertWriter implements ItemWriterInterface
 {
     private Connection $connection;

--- a/src/batch-doctrine-dbal/src/DoctrineDBALQueryReader.php
+++ b/src/batch-doctrine-dbal/src/DoctrineDBALQueryReader.php
@@ -11,6 +11,10 @@ use Generator;
 use Yokai\Batch\Exception\InvalidArgumentException;
 use Yokai\Batch\Job\Item\ItemReaderInterface;
 
+/**
+ * This {@see ItemReaderInterface} executes an SQL query to a Doctrine connection,
+ * and iterate over each result as an item.
+ */
 final class DoctrineDBALQueryReader implements ItemReaderInterface
 {
     private Connection $connection;

--- a/src/batch-doctrine-dbal/src/DoctrineDBALUpsert.php
+++ b/src/batch-doctrine-dbal/src/DoctrineDBALUpsert.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Yokai\Batch\Bridge\Doctrine\DBAL;
 
+/**
+ * This model object is used by {@see DoctrineDBALUpsertWriter}.
+ * It holds table, data and identity to perform upsert operation.
+ */
 final class DoctrineDBALUpsert
 {
     private string $table;

--- a/src/batch-doctrine-dbal/src/DoctrineDBALUpsertWriter.php
+++ b/src/batch-doctrine-dbal/src/DoctrineDBALUpsertWriter.php
@@ -12,6 +12,11 @@ use Yokai\Batch\Job\JobExecutionAwareInterface;
 use Yokai\Batch\Job\JobExecutionAwareTrait;
 use Yokai\Batch\Warning;
 
+/**
+ * This {@see ItemWriterInterface} will insert/update items to one or multiple tables,
+ * via a Doctrine {@see Connection}.
+ * All items must instance of {@see DoctrineDBALUpsert}.
+ */
 final class DoctrineDBALUpsertWriter implements
     ItemWriterInterface,
     JobExecutionAwareInterface

--- a/src/batch-doctrine-orm/src/EntityReader.php
+++ b/src/batch-doctrine-orm/src/EntityReader.php
@@ -9,16 +9,12 @@ use Doctrine\Persistence\ManagerRegistry;
 use Yokai\Batch\Exception\UnexpectedValueException;
 use Yokai\Batch\Job\Item\ItemReaderInterface;
 
+/**
+ * This {@see ItemReaderInterface} executes an SQL query to a Doctrine connection,
+ */
 final class EntityReader implements ItemReaderInterface
 {
-    /**
-     * @var ManagerRegistry
-     */
     private ManagerRegistry $doctrine;
-
-    /**
-     * @var string
-     */
     private string $class;
 
     public function __construct(ManagerRegistry $doctrine, string $class)

--- a/src/batch-doctrine-persistence/src/ObjectWriter.php
+++ b/src/batch-doctrine-persistence/src/ObjectWriter.php
@@ -9,11 +9,12 @@ use Doctrine\Persistence\ObjectManager;
 use Yokai\Batch\Exception\InvalidArgumentException;
 use Yokai\Batch\Job\Item\ItemWriterInterface;
 
+/**
+ * This {@see ItemWriterInterface} will persist and flush all items,
+ * via a Doctrine {@see ObjectManager}.
+ */
 final class ObjectWriter implements ItemWriterInterface
 {
-    /**
-     * @var ManagerRegistry
-     */
     private ManagerRegistry $doctrine;
 
     /**

--- a/src/batch/docs/domain/item-job.md
+++ b/src/batch/docs/domain/item-job.md
@@ -2,8 +2,8 @@
 
 ## What is an item ?
 
-The library allows you to declare and execute jobs, but wait why did you named it batch then ?
-There you are, the Item Job is where batch processing actually starts.
+The library allows you to declare and execute jobs, but wait why do we named it batch then ?
+There you are, the `ItemJob` is where batch processing actually starts.
 
 This is just a job that has been prepared to batch handle items.
 

--- a/src/batch/docs/domain/item-job/item-processor.md
+++ b/src/batch/docs/domain/item-job/item-processor.md
@@ -7,10 +7,16 @@ It can be any class implementing [ItemProcessorInterface](../../../src/Job/Item/
 ## What types of item processors exists ?
 
 **Built-in item processors:**
-- [NullProcessor](../../../src/Job/Item/Processor/NullProcessor.php):
-  perform no transformation on items.
+- [ArrayMapProcessor](../../../src/Job/Item/Processor/ArrayMapProcessor.php):
+  apply a callback to each element of array items.
 - [ChainProcessor](../../../src/Job/Item/Processor/ChainProcessor.php):
   chain transformation of multiple item processor, one after the other.
+- [FilterUniqueProcessor](../../../src/Job/Item/Processor/FilterUniqueProcessor.php):
+  assign an identifier to each item, and skip already encountered items.
+- [NullProcessor](../../../src/Job/Item/Processor/NullProcessor.php):
+  perform no transformation on items.
+- [RoutingProcessor](../../../src/Job/Item/Processor/RoutingProcessor.php):
+  route processing to different processor based on your logic.
 
 **Item processors from bridges:**
 - [SkipInvalidItemProcessor (`symfony/validator`)](https://github.com/yokai-php/batch-symfony-validator/blob/0.x/src/SkipInvalidItemProcessor.php):

--- a/src/batch/docs/domain/item-job/item-reader.md
+++ b/src/batch/docs/domain/item-job/item-reader.md
@@ -7,14 +7,26 @@ It can be any class implementing [ItemReaderInterface](../../../src/Job/Item/Ite
 ## What types of item readers exists ?
 
 **Built-in item readers:**
-- [StaticIterableReader](../../../src/Job/Item/Reader/StaticIterableReader.php):
-  read from an iterable you provide during construction.
+- [FixedColumnSizeFileReader](../../../src/Job/Item/Reader/Filesystem/FixedColumnSizeFileReader.php):
+  read a file line by line, and decode each line with fixed columns size to an array.
+- [JsonLinesReader](../../../src/Job/Item/Reader/Filesystem/JsonLinesReader.php):
+  read a file line by line, and decode each line as JSON.
+- [AddMetadataReader](../../../src/Job/Item/Reader/AddMetadataReader.php):
+  decorates another reader by adding static information to each read item.
+- [IndexWithReader](../../../src/Job/Item/Reader/IndexWithReader.php):
+  decorates another reader by changing index of each item.
+- [ParameterAccessorReader](../../../src/Job/Item/Reader/ParameterAccessorReader.php):
+  read from an inmemory value located at some configurable place.
 - [SequenceReader](../../../src/Job/Item/Reader/SequenceReader.php):
   read from multiple item reader, one after the other.
+- [StaticIterableReader](../../../src/Job/Item/Reader/StaticIterableReader.php):
+  read from an iterable you provide during construction.
 
 **Item readers from bridges:**
 - [FlatFileReader (`box/spout`)](https://github.com/yokai-php/batch-box-spout/blob/0.x/src/FlatFileReader.php):
   read from any CSV/ODS/XLSX file.
+- [DoctrineDBALQueryReader (`doctrine/dbal`)](https://github.com/yokai-php/batch-doctrine-dbal/blob/0.x/src/DoctrineDBALQueryReader.php):
+  read execute an SQL query and iterate over results.
 - [EntityReader (`doctrine/orm`)](https://github.com/yokai-php/batch-doctrine-orm/blob/0.x/src/EntityReader.php):
   read from any Doctrine ORM entity.
 

--- a/src/batch/docs/domain/item-job/item-writer.md
+++ b/src/batch/docs/domain/item-job/item-writer.md
@@ -7,12 +7,22 @@ It can be any class implementing [ItemWriterInterface](../../../src/Job/Item/Ite
 ## What types of item writers exists ?
 
 **Built-in item writers:**
-- [NullWriter](../../../src/Job/Item/Writer/NullWriter.php):
-  do not write items.
+- [JsonLinesWriter](../../../src/Job/Item/Writer/Filesystem/JsonLinesWriter.php):
+  write items as a json string each on a line of a file.
 - [ChainWriter](../../../src/Job/Item/Writer/ChainWriter.php):
   write items on multiple item writers.
+- [NullWriter](../../../src/Job/Item/Writer/NullWriter.php):
+  do not write items.
+- [RoutingWriter](../../../src/Job/Item/Writer/RoutingWriter.php):
+  route writing to different writer based on your logic.
+- [SummaryWriter](../../../src/Job/Item/Writer/SummaryWriter.php):
+  write items to a job summary value.
 
 **Item writers from bridges:**
+- [DoctrineDBALInsertWriter (`doctrine/dbal`)](https://github.com/yokai-php/batch-doctrine-dbal/blob/0.x/src/DoctrineDBALInsertWriter.php):
+  write items by inserting in a table via a Doctrine `Connection`.
+- [DoctrineDBALUpsertWriter (`doctrine/dbal`)](https://github.com/yokai-php/batch-doctrine-dbal/blob/0.x/src/DoctrineDBALUpsertWriter.php):
+  write items by inserting/updating in a table via a Doctrine `Connection`.
 - [ObjectWriter (`doctrine/persistence`)](https://github.com/yokai-php/batch-doctrine-persistence/blob/0.x/src/ObjectWriter.php):
   write items to any Doctrine `ObjectManager`.
 - [FlatFileWriter (`box/spout`)](https://github.com/yokai-php/batch-box-spout/blob/0.x/src/FlatFileWriter.php):

--- a/src/batch/src/Job/Item/ElementConfiguratorTrait.php
+++ b/src/batch/src/Job/Item/ElementConfiguratorTrait.php
@@ -9,6 +9,14 @@ use Yokai\Batch\Job\JobParametersAwareInterface;
 use Yokai\Batch\Job\SummaryAwareInterface;
 use Yokai\Batch\JobExecution;
 
+/**
+ * Use this trait whenever you have objects that might implement :
+ * - {@see JobExecutionAwareInterface}
+ * - {@see JobParametersAwareInterface}
+ * - {@see SummaryAwareInterface}
+ * - {@see InitializableInterface}
+ * - {@see FlushableInterface}
+ */
 trait ElementConfiguratorTrait
 {
     private function configureElementJobContext(object $element, JobExecution $jobExecution): void

--- a/src/batch/src/Job/Item/FlushableInterface.php
+++ b/src/batch/src/Job/Item/FlushableInterface.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Yokai\Batch\Job\Item;
 
+/**
+ * This interface might be used by any {@see ItemReaderInterface},
+ * {@see ItemProcessorInterface} or {@see ItemWriterInterface}.
+ * A class implementing this interface will be called by {@see ItemJob}
+ * at the end of the execution.
+ */
 interface FlushableInterface
 {
     /**

--- a/src/batch/src/Job/Item/InitializableInterface.php
+++ b/src/batch/src/Job/Item/InitializableInterface.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Yokai\Batch\Job\Item;
 
+/**
+ * This interface might be used by any {@see ItemReaderInterface},
+ * {@see ItemProcessorInterface} or {@see ItemWriterInterface}.
+ * A class implementing this interface will be called by {@see ItemJob}
+ * at the beginning of the execution.
+ */
 interface InitializableInterface
 {
     /**

--- a/src/batch/src/Job/Item/ItemProcessorInterface.php
+++ b/src/batch/src/Job/Item/ItemProcessorInterface.php
@@ -6,13 +6,18 @@ namespace Yokai\Batch\Job\Item;
 
 use Yokai\Batch\Job\Item\Exception\SkipItemException;
 
+/**
+ * The item reader is responsible for transforming every read items in {@see ItemJob}.
+ */
 interface ItemProcessorInterface
 {
     /**
-     * @param mixed $item
+     * Transform the item before writing.
      *
-     * @return mixed
-     * @throws SkipItemException
+     * @param mixed $item The item read
+     *
+     * @return mixed The item transformed
+     * @throws SkipItemException If the item should be skipped
      */
     public function process($item);
 }

--- a/src/batch/src/Job/Item/ItemReaderInterface.php
+++ b/src/batch/src/Job/Item/ItemReaderInterface.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace Yokai\Batch\Job\Item;
 
+/**
+ * The item reader is responsible for fetching items in {@see ItemJob}.
+ */
 interface ItemReaderInterface
 {
     /**
+     * A list of items to process and write.
+     *
      * @return iterable
      * @phpstan-return iterable<mixed>
      */

--- a/src/batch/src/Job/Item/ItemWriterInterface.php
+++ b/src/batch/src/Job/Item/ItemWriterInterface.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace Yokai\Batch\Job\Item;
 
+/**
+ * The item writer is responsible for writing transformed items in {@see ItemJob}.
+ */
 interface ItemWriterInterface
 {
     /**
-     * @param iterable $items
+     * Writes items.
+     *
+     * @param iterable $items A batch of items to write
      * @phpstan-param iterable<mixed> $items
      */
     public function write(iterable $items): void;

--- a/src/batch/src/Job/Item/Processor/ArrayMapProcessor.php
+++ b/src/batch/src/Job/Item/Processor/ArrayMapProcessor.php
@@ -8,6 +8,9 @@ use Closure;
 use Yokai\Batch\Exception\UnexpectedValueException;
 use Yokai\Batch\Job\Item\ItemProcessorInterface;
 
+/**
+ * This {@see ItemProcessorInterface} calls {@see array_map} on each item.
+ */
 final class ArrayMapProcessor implements ItemProcessorInterface
 {
     private Closure $callback;

--- a/src/batch/src/Job/Item/Processor/ChainProcessor.php
+++ b/src/batch/src/Job/Item/Processor/ChainProcessor.php
@@ -7,6 +7,11 @@ namespace Yokai\Batch\Job\Item\Processor;
 use Yokai\Batch\Job\Item\AbstractElementDecorator;
 use Yokai\Batch\Job\Item\ItemProcessorInterface;
 
+/**
+ * This {@see ItemProcessorInterface} owns a collection of processors
+ * and call each processor one after the other, providing previous result to the next processor.
+ * If you are familiar with the middleware architecture, it is very much alike.
+ */
 final class ChainProcessor extends AbstractElementDecorator implements ItemProcessorInterface
 {
     /**

--- a/src/batch/src/Job/Item/Processor/NullProcessor.php
+++ b/src/batch/src/Job/Item/Processor/NullProcessor.php
@@ -6,6 +6,9 @@ namespace Yokai\Batch\Job\Item\Processor;
 
 use Yokai\Batch\Job\Item\ItemProcessorInterface;
 
+/**
+ * This {@see ItemProcessorInterface} perform no transformation.
+ */
 final class NullProcessor implements ItemProcessorInterface
 {
     /**

--- a/src/batch/src/Job/Item/Processor/RoutingProcessor.php
+++ b/src/batch/src/Job/Item/Processor/RoutingProcessor.php
@@ -13,6 +13,10 @@ use Yokai\Batch\Job\JobExecutionAwareInterface;
 use Yokai\Batch\Job\JobExecutionAwareTrait;
 use Yokai\Batch\Finder\FinderInterface;
 
+/**
+ * This {@see ItemProcessorInterface} calls different processor for items,
+ * based on the logic you put in the provided {@see FinderInterface}.
+ */
 final class RoutingProcessor implements
     ItemProcessorInterface,
     InitializableInterface,

--- a/src/batch/src/Job/Item/Reader/AddMetadataReader.php
+++ b/src/batch/src/Job/Item/Reader/AddMetadataReader.php
@@ -9,6 +9,11 @@ use Yokai\Batch\Exception\UnexpectedValueException;
 use Yokai\Batch\Job\Item\AbstractElementDecorator;
 use Yokai\Batch\Job\Item\ItemReaderInterface;
 
+/**
+ * This {@see ItemReaderInterface} decorates another reader.
+ * The decorated reader must return array items.
+ * This reader will add the data provided as constructor argument to each item.
+ */
 final class AddMetadataReader extends AbstractElementDecorator implements ItemReaderInterface
 {
     private ItemReaderInterface $reader;

--- a/src/batch/src/Job/Item/Reader/Filesystem/FixedColumnSizeFileReader.php
+++ b/src/batch/src/Job/Item/Reader/Filesystem/FixedColumnSizeFileReader.php
@@ -12,6 +12,11 @@ use Yokai\Batch\Job\JobExecutionAwareInterface;
 use Yokai\Batch\Job\JobExecutionAwareTrait;
 use Yokai\Batch\Job\Parameters\JobParameterAccessorInterface;
 
+/**
+ * This {@see ItemReaderInterface} reads from a file and convert every line to an array.
+ * Every line must have fixed size columns,
+ * according to the parameters provided as constructor argument.
+ */
 final class FixedColumnSizeFileReader implements
     ItemReaderInterface,
     JobExecutionAwareInterface
@@ -32,14 +37,7 @@ final class FixedColumnSizeFileReader implements
      */
     private array $columns;
 
-    /**
-     * @var string
-     */
     private string $headersMode;
-
-    /**
-     * @var JobParameterAccessorInterface
-     */
     private JobParameterAccessorInterface $filePath;
 
     /**

--- a/src/batch/src/Job/Item/Reader/Filesystem/JsonLinesReader.php
+++ b/src/batch/src/Job/Item/Reader/Filesystem/JsonLinesReader.php
@@ -11,6 +11,11 @@ use Yokai\Batch\Job\JobExecutionAwareInterface;
 use Yokai\Batch\Job\JobExecutionAwareTrait;
 use Yokai\Batch\Job\Parameters\JobParameterAccessorInterface;
 
+/**
+ * This {@see ItemReaderInterface} reads from a file and convert every line to an array.
+ * Every line must be a valid JSON value (accepted by {@see json_decode} function).
+ * @link https://jsonlines.org/
+ */
 final class JsonLinesReader implements
     ItemReaderInterface,
     JobExecutionAwareInterface

--- a/src/batch/src/Job/Item/Reader/SequenceReader.php
+++ b/src/batch/src/Job/Item/Reader/SequenceReader.php
@@ -7,6 +7,9 @@ namespace Yokai\Batch\Job\Item\Reader;
 use Yokai\Batch\Job\Item\AbstractElementDecorator;
 use Yokai\Batch\Job\Item\ItemReaderInterface;
 
+/**
+ * This {@see ItemReaderInterface} reads from multiple readers, one after the other.
+ */
 final class SequenceReader extends AbstractElementDecorator implements ItemReaderInterface
 {
     /**

--- a/src/batch/src/Job/Item/Reader/StaticIterableReader.php
+++ b/src/batch/src/Job/Item/Reader/StaticIterableReader.php
@@ -6,6 +6,9 @@ namespace Yokai\Batch\Job\Item\Reader;
 
 use Yokai\Batch\Job\Item\ItemReaderInterface;
 
+/**
+ * This {@see ItemReaderInterface} reads from items provided as constructor argument.
+ */
 final class StaticIterableReader implements ItemReaderInterface
 {
     /**

--- a/src/batch/src/Job/Item/Writer/ChainWriter.php
+++ b/src/batch/src/Job/Item/Writer/ChainWriter.php
@@ -7,6 +7,9 @@ namespace Yokai\Batch\Job\Item\Writer;
 use Yokai\Batch\Job\Item\AbstractElementDecorator;
 use Yokai\Batch\Job\Item\ItemWriterInterface;
 
+/**
+ * This {@see ItemWriterInterface} writes to multiple other writers.
+ */
 final class ChainWriter extends AbstractElementDecorator implements ItemWriterInterface
 {
     /**

--- a/src/batch/src/Job/Item/Writer/Filesystem/JsonLinesWriter.php
+++ b/src/batch/src/Job/Item/Writer/Filesystem/JsonLinesWriter.php
@@ -12,6 +12,10 @@ use Yokai\Batch\Job\JobExecutionAwareInterface;
 use Yokai\Batch\Job\JobExecutionAwareTrait;
 use Yokai\Batch\Job\Parameters\JobParameterAccessorInterface;
 
+/**
+ * This {@see ItemWriterInterface} writes each item as a JSON string to a file.
+ * @link https://jsonlines.org/
+ */
 final class JsonLinesWriter implements
     ItemWriterInterface,
     InitializableInterface,

--- a/src/batch/src/Job/Item/Writer/NullWriter.php
+++ b/src/batch/src/Job/Item/Writer/NullWriter.php
@@ -6,6 +6,9 @@ namespace Yokai\Batch\Job\Item\Writer;
 
 use Yokai\Batch\Job\Item\ItemWriterInterface;
 
+/**
+ * This {@see ItemWriterInterface} writes nothing.
+ */
 final class NullWriter implements ItemWriterInterface
 {
     /**

--- a/src/batch/src/Job/Item/Writer/RoutingWriter.php
+++ b/src/batch/src/Job/Item/Writer/RoutingWriter.php
@@ -13,6 +13,10 @@ use Yokai\Batch\Job\JobExecutionAwareInterface;
 use Yokai\Batch\Job\JobExecutionAwareTrait;
 use Yokai\Batch\Finder\FinderInterface;
 
+/**
+ * This {@see ItemWriterInterface} calls different writer for items,
+ * based on the logic you put in the provided {@see FinderInterface}.
+ */
 final class RoutingWriter implements
     ItemWriterInterface,
     InitializableInterface,

--- a/src/batch/src/Job/JobInterface.php
+++ b/src/batch/src/Job/JobInterface.php
@@ -5,11 +5,19 @@ declare(strict_types=1);
 namespace Yokai\Batch\Job;
 
 use Yokai\Batch\JobExecution;
+use Yokai\Batch\Launcher\SimpleJobLauncher;
 
+/**
+ * A job is the place where everything starts.
+ */
 interface JobInterface
 {
     /**
-     * @param JobExecution $jobExecution
+     * Execute the job.
+     * Called by {@see SimpleJobLauncher}.
+     *
+     * @param JobExecution $jobExecution Current execution representing
+     *                                   the one that is going to start
      */
     public function execute(JobExecution $jobExecution): void;
 }


### PR DESCRIPTION
As a developer I like to find a bit of documentation on every class I'm supposed to use.

This PR introduce few lines of class PhpDoc, so each class/interface/trait that a user may use is described. 