### PR TITLE
Allow jobs to define their name using interface method in a Symfony framework context

### DIFF
--- a/src/batch-symfony-framework/docs/getting-started.md
+++ b/src/batch-symfony-framework/docs/getting-started.md
@@ -124,3 +124,7 @@ Then the job will be triggered with its service id:
 /** @var \Yokai\Batch\Launcher\JobLauncherInterface $launcher */
 $launcher->launch(\App\Job\ImportUsersJob::class);
 ```
+
+> **note**: when registering jobs with dedicated class, you can use the
+> [JobWithStaticNameInterface](../src/JobWithStaticNameInterface.php) interface
+> to be able to specify the job name of your service.

--- a/src/batch-symfony-framework/src/DependencyInjection/CompilerPass/RegisterJobsCompilerPass.php
+++ b/src/batch-symfony-framework/src/DependencyInjection/CompilerPass/RegisterJobsCompilerPass.php
@@ -7,7 +7,9 @@ namespace Yokai\Batch\Bridge\Symfony\Framework\DependencyInjection\CompilerPass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+use Yokai\Batch\Bridge\Symfony\Framework\JobWithStaticNameInterface;
 
 final class RegisterJobsCompilerPass implements CompilerPassInterface
 {
@@ -18,12 +20,30 @@ final class RegisterJobsCompilerPass implements CompilerPassInterface
     {
         $jobs = [];
         foreach ($container->findTaggedServiceIds('yokai_batch.job') as $serviceId => $tags) {
+            $serviceDefinition = $container->findDefinition($serviceId);
             foreach ($tags as $attributes) {
-                $jobs[$attributes['job'] ?? $serviceId] = new Reference($serviceId);
+                $jobs[$this->getJobName($serviceId, $serviceDefinition, $attributes)] = new Reference($serviceId);
             }
         }
 
         $container->getDefinition('yokai_batch.job_registry')
             ->setArgument('$jobs', ServiceLocatorTagPass::register($container, $jobs));
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $attributes
+     */
+    private function getJobName(string $id, Definition $definition, array $attributes): string
+    {
+        if (isset($attributes['job'])) {
+            return (string)$attributes['job'];
+        }
+
+        $serviceClass = $definition->getClass();
+        if (\is_a($serviceClass, JobWithStaticNameInterface::class, true)) {
+            return $serviceClass::getJobName();
+        }
+
+        return $id;
     }
 }

--- a/src/batch-symfony-framework/src/DependencyInjection/CompilerPass/RegisterJobsCompilerPass.php
+++ b/src/batch-symfony-framework/src/DependencyInjection/CompilerPass/RegisterJobsCompilerPass.php
@@ -40,7 +40,7 @@ final class RegisterJobsCompilerPass implements CompilerPassInterface
         }
 
         $serviceClass = $definition->getClass();
-        if (\is_a($serviceClass, JobWithStaticNameInterface::class, true)) {
+        if ($serviceClass !== null && \is_a($serviceClass, JobWithStaticNameInterface::class, true)) {
             return $serviceClass::getJobName();
         }
 

--- a/src/batch-symfony-framework/src/JobWithStaticNameInterface.php
+++ b/src/batch-symfony-framework/src/JobWithStaticNameInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Bridge\Symfony\Framework;
+
+/**
+ * A job that implement this interface can define the associated job name via a static method.
+ * This is very useful if you are registering jobs using PSR services registering.
+ * Without implementing, the job name will be the service id,
+ * in the case of a PSR service registering : the job class.
+ */
+interface JobWithStaticNameInterface
+{
+    public static function getJobName(): string;
+}

--- a/src/batch-symfony-framework/tests/Fixtures/DummyJob.php
+++ b/src/batch-symfony-framework/tests/Fixtures/DummyJob.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Tests\Bridge\Symfony\Framework\Fixtures;
+
+use Yokai\Batch\Job\AbstractJob;
+use Yokai\Batch\JobExecution;
+
+final class DummyJob extends AbstractJob
+{
+    protected function doExecute(JobExecution $jobExecution): void
+    {
+        // dummy
+    }
+}

--- a/src/batch-symfony-framework/tests/Fixtures/DummyJobWithName.php
+++ b/src/batch-symfony-framework/tests/Fixtures/DummyJobWithName.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Tests\Bridge\Symfony\Framework\Fixtures;
+
+use Yokai\Batch\Bridge\Symfony\Framework\JobWithStaticNameInterface;
+use Yokai\Batch\Job\AbstractJob;
+use Yokai\Batch\JobExecution;
+
+final class DummyJobWithName extends AbstractJob implements JobWithStaticNameInterface
+{
+    public static function getJobName(): string
+    {
+        return 'export_orders_job';
+    }
+
+    protected function doExecute(JobExecution $jobExecution): void
+    {
+        // dummy
+    }
+}


### PR DESCRIPTION
Following the idea where a developer can create a job by simply adding a class in src, an interface is added to provide full control of job name, when using FQCN is not wanted.

https://github.com/yokai-php/batch-src/pull/46/files#diff-04e3a15da827207aac89bbfa1bf6414b6ca1ef7fa9fac6f09d14fbaeaba49e5c
