### PR TITLE
Add missing last line in Exception trace capture

### DIFF
--- a/src/batch/src/Failure.php
+++ b/src/batch/src/Failure.php
@@ -47,7 +47,7 @@ final class Failure implements \Stringable
             $exception->getMessage(),
             $exception->getCode(),
             $parameters,
-            $exception->getTraceAsString()
+            'in ' . $exception->getFile() . ':' . $exception->getLine() . PHP_EOL . $exception->getTraceAsString()
         );
     }
 

--- a/src/batch/src/Failure.php
+++ b/src/batch/src/Failure.php
@@ -47,7 +47,7 @@ final class Failure implements \Stringable
             $exception->getMessage(),
             $exception->getCode(),
             $parameters,
-            'in ' . $exception->getFile() . ':' . $exception->getLine() . PHP_EOL . $exception->getTraceAsString()
+            self::buildTrace($exception)
         );
     }
 
@@ -82,5 +82,18 @@ final class Failure implements \Stringable
     public function getTrace(): ?string
     {
         return $this->trace;
+    }
+
+    private static function buildTrace(Throwable $exception, bool $deep = false): string
+    {
+        $trace = ($deep ? 'Caused by: ' : '') . \get_class($exception) . ': ' . $exception->getMessage() .
+            ' (at ' . $exception->getFile() . '(' . $exception->getLine() . '))' . PHP_EOL .
+            \str_replace("\n", \PHP_EOL, $exception->getTraceAsString());
+
+        if ($exception->getPrevious()) {
+            $trace .= \PHP_EOL . self::buildTrace($exception->getPrevious(), true);
+        }
+
+        return $trace;
     }
 }

--- a/src/batch/tests/FailureTest.php
+++ b/src/batch/tests/FailureTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Tests;
+
+use Generator;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Yokai\Batch\Failure;
+
+class FailureTest extends TestCase
+{
+    /**
+     * @dataProvider failures
+     */
+    public function test(
+        callable $load,
+        string $class,
+        int $code,
+        string $message,
+        array $trace,
+        array $parameters,
+        string $string
+    ): void {
+        /** @var Failure $failure */
+        $failure = $load();
+        self::assertSame($class, $failure->getClass());
+        self::assertSame($code, $failure->getCode());
+        self::assertSame($message, $failure->getMessage());
+        foreach ($trace as $fragment) {
+            self::assertStringContainsString($fragment, $failure->getTrace());
+        }
+        self::assertSame($parameters, $failure->getParameters());
+        self::assertSame($string, (string)$failure);
+    }
+
+    public function failures(): Generator
+    {
+        yield [
+            fn () => Failure::fromException(
+                new LogicException('I will fail because of {var}'),
+                ['{var}' => 'test var']
+            ),
+            'LogicException',
+            0,
+            'I will fail because of {var}',
+            [
+                'LogicException: I will fail because of {var}',
+            ],
+            ['{var}' => 'test var'],
+            'I will fail because of test var'
+        ];
+        yield [
+            fn () => Failure::fromException(
+                new RuntimeException('This is a test', 123, new LogicException('Previous exception'))
+            ),
+            'RuntimeException',
+            123,
+            'This is a test',
+            [
+                'RuntimeException: This is a test',
+                'Caused by: LogicException: Previous exception',
+            ],
+            [],
+            'This is a test'
+        ];
+    }
+}


### PR DESCRIPTION
`Throwable::getTraceAsString` method do not include the line where the exception is thrown.
This PR is adding this information to the captured stacktrace when converting Exceptions to Failures.

Now, traces will be something like
```
Exception: Thrown from class C (at /in/uVj23(43))
#0 /in/uVj23(35): C->exc()
#1 /in/uVj23(50): C->doexc()
#2 /in/uVj23(54): fail2()
#3 /in/uVj23(58): fail1()
#4 {main}
Caused by: Exception: Thrown from class B (at /in/uVj23(29))
#0 /in/uVj23(40): B->exc()
#1 /in/uVj23(35): C->exc()
#2 /in/uVj23(50): C->doexc()
#3 /in/uVj23(54): fail2()
#4 /in/uVj23(58): fail1()
#5 {main}
```