### PR TITLE
Add an item writer that will only write items satisfying a condition

### DIFF
--- a/src/batch/docs/domain/item-job/item-writer.md
+++ b/src/batch/docs/domain/item-job/item-writer.md
@@ -11,6 +11,8 @@ It can be any class implementing [ItemWriterInterface](../../../src/Job/Item/Ite
   write items as a json string each on a line of a file.
 - [ChainWriter](../../../src/Job/Item/Writer/ChainWriter.php):
   write items on multiple item writers.
+- [ConditionalWriter](../../../src/Job/Item/Writer/ConditionalWriter.php):
+  will only write items that are matching your conditions.
 - [NullWriter](../../../src/Job/Item/Writer/NullWriter.php):
   do not write items.
 - [RoutingWriter](../../../src/Job/Item/Writer/RoutingWriter.php):

--- a/src/batch/src/Job/Item/Writer/ConditionalWriter.php
+++ b/src/batch/src/Job/Item/Writer/ConditionalWriter.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Job\Item\Writer;
+
+use Yokai\Batch\Job\Item\ElementConfiguratorTrait;
+use Yokai\Batch\Job\Item\FlushableInterface;
+use Yokai\Batch\Job\Item\InitializableInterface;
+use Yokai\Batch\Job\Item\ItemWriterInterface;
+use Closure;
+use Yokai\Batch\Job\JobExecutionAwareInterface;
+use Yokai\Batch\Job\JobExecutionAwareTrait;
+
+/**
+ * This {@see ItemWriterInterface} will transfer writing
+ * to another {@see ItemWriterInterface},
+ * if the closure you provided tells to.
+ */
+final class ConditionalWriter implements
+    ItemWriterInterface,
+    JobExecutionAwareInterface,
+    InitializableInterface,
+    FlushableInterface
+{
+    use JobExecutionAwareTrait;
+    use ElementConfiguratorTrait;
+
+    private bool $initialized = false;
+
+    public function __construct(
+        private Closure $shouldWrite,
+        private ItemWriterInterface $writer,
+    ) {
+    }
+
+    public function write(iterable $items): void
+    {
+        $keptItems = [];
+        foreach ($items as $item) {
+            if (($this->shouldWrite)($item, $this->jobExecution)) {
+                $keptItems[] = $item;
+            }
+        }
+
+        if ($keptItems === []) {
+            return;
+        }
+
+        if (!$this->initialized) {
+            $this->configureElementJobContext($this->writer, $this->jobExecution);
+            $this->initializeElement($this->writer);
+            $this->initialized = true;
+        }
+
+        $this->writer->write($keptItems);
+    }
+
+    public function initialize(): void
+    {
+        $this->initialized = false;
+    }
+
+    public function flush(): void
+    {
+        if ($this->initialized) {
+            $this->flushElement($this->writer);
+        }
+    }
+}

--- a/src/batch/tests/Job/Item/Writer/ConditionalWriterTest.php
+++ b/src/batch/tests/Job/Item/Writer/ConditionalWriterTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Tests\Job\Item\Writer;
+
+use Yokai\Batch\Job\Item\Writer\ConditionalWriter;
+use PHPUnit\Framework\TestCase;
+use Yokai\Batch\JobExecution;
+use Yokai\Batch\Test\Job\Item\Writer\InMemoryWriter;
+use Yokai\Batch\Test\Job\Item\Writer\TestDebugWriter;
+
+class ConditionalWriterTest extends TestCase
+{
+    public function testWriteSomething(): void
+    {
+        $writer = new ConditionalWriter(
+            fn (int $number) => ($number % 2) === 0,
+            $debugWriter = new TestDebugWriter($memoryWriter = new InMemoryWriter())
+        );
+
+        $writer->setJobExecution(JobExecution::createRoot('123', 'test.conditional_writer'));
+        $writer->initialize();
+        $writer->write([1, 2, 3, 4, 5]);
+        $writer->write([6, 7, 8]);
+        $writer->flush();
+
+        $debugWriter->assertWasConfigured();
+        $debugWriter->assertWasUsed();
+        self::assertSame([[2, 4], [6, 8]], $memoryWriter->getBatchItems());
+    }
+
+    public function testWriteNothing(): void
+    {
+        $writer = new ConditionalWriter(
+            fn () => false,
+            $debugWriter = new TestDebugWriter($memoryWriter = new InMemoryWriter())
+        );
+
+        $writer->setJobExecution(JobExecution::createRoot('123', 'test.conditional_writer'));
+        $writer->initialize();
+        $writer->write([1, 2, 3, 4, 5]);
+        $writer->write([6, 7, 8]);
+        $writer->flush();
+
+        $debugWriter->assertWasNotConfigured();
+        $debugWriter->assertWasNotUsed();
+        self::assertSame([], $memoryWriter->getBatchItems());
+    }
+}


### PR DESCRIPTION
Alone, this component might not be useful (because you can skip any item within the process).
But combined to any other writer (for instance the ChainWriter), it will unlock some possibilities.