### PR TITLE
Add writers that will launch other jobs 

### DIFF
--- a/src/batch/docs/domain/item-job/item-writer.md
+++ b/src/batch/docs/domain/item-job/item-writer.md
@@ -13,6 +13,10 @@ It can be any class implementing [ItemWriterInterface](../../../src/Job/Item/Ite
   write items on multiple item writers.
 - [ConditionalWriter](../../../src/Job/Item/Writer/ConditionalWriter.php):
   will only write items that are matching your conditions.
+- [LaunchJobForEachItemWriter](../../../src/Job/Item/Writer/LaunchJobForEachItemWriter.php):
+  launch another job for each items.
+- [LaunchJobForItemsBatchWriter](../../../src/Job/Item/Writer/LaunchJobForItemsBatchWriter.php):
+  launch another job for each item batches.
 - [NullWriter](../../../src/Job/Item/Writer/NullWriter.php):
   do not write items.
 - [RoutingWriter](../../../src/Job/Item/Writer/RoutingWriter.php):

--- a/src/batch/src/Job/Item/Writer/LaunchJobForEachItemWriter.php
+++ b/src/batch/src/Job/Item/Writer/LaunchJobForEachItemWriter.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Job\Item\Writer;
+
+use Closure;
+use Yokai\Batch\Job\Item\ItemWriterInterface;
+use Yokai\Batch\Job\JobExecutionAwareInterface;
+use Yokai\Batch\Job\JobExecutionAwareTrait;
+use Yokai\Batch\Launcher\JobLauncherInterface;
+
+/**
+ * This {@see ItemWriterInterface} will trigger a job for each written items.
+ */
+final class LaunchJobForEachItemWriter implements ItemWriterInterface, JobExecutionAwareInterface
+{
+    use JobExecutionAwareTrait;
+
+    public function __construct(
+        private JobLauncherInterface $launcher,
+        private string $jobName,
+        private string|Closure $parameter,
+    ) {
+    }
+
+    public function write(iterable $items): void
+    {
+        foreach ($items as $item) {
+            if (\is_string($this->parameter)) {
+                $parameters = [$this->parameter => $item];
+            } else {
+                $parameters = ($this->parameter)($item, $this->jobExecution);
+            }
+
+            $execution = $this->launcher->launch($this->jobName, $parameters);
+            $this->jobExecution->getLogger()->notice(
+                'Triggered job for item.',
+                ['jobName' => $execution->getJobName(), 'executionId' => $execution->getId()]
+            );
+        }
+    }
+}

--- a/src/batch/src/Job/Item/Writer/LaunchJobForItemsBatchWriter.php
+++ b/src/batch/src/Job/Item/Writer/LaunchJobForItemsBatchWriter.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Job\Item\Writer;
+
+use Closure;
+use Yokai\Batch\Job\Item\ItemWriterInterface;
+use Yokai\Batch\Job\JobExecutionAwareInterface;
+use Yokai\Batch\Job\JobExecutionAwareTrait;
+use Yokai\Batch\Launcher\JobLauncherInterface;
+
+/**
+ * This {@see ItemWriterInterface} will trigger a job for each written item batches.
+ */
+final class LaunchJobForItemsBatchWriter implements ItemWriterInterface, JobExecutionAwareInterface
+{
+    use JobExecutionAwareTrait;
+
+    public function __construct(
+        private JobLauncherInterface $launcher,
+        private string $jobName,
+        private string|Closure $parameter,
+    ) {
+    }
+
+    public function write(iterable $items): void
+    {
+        if (\is_string($this->parameter)) {
+            $parameters = [$this->parameter => $items];
+        } else {
+            $parameters = ($this->parameter)($items, $this->jobExecution);
+        }
+
+        $execution = $this->launcher->launch($this->jobName, $parameters);
+        $this->jobExecution->getLogger()->notice(
+            'Triggered job for items batch.',
+            ['jobName' => $execution->getJobName(), 'executionId' => $execution->getId()]
+        );
+    }
+}
+

--- a/src/batch/src/Job/Item/Writer/LaunchJobForItemsBatchWriter.php
+++ b/src/batch/src/Job/Item/Writer/LaunchJobForItemsBatchWriter.php
@@ -39,4 +39,3 @@ final class LaunchJobForItemsBatchWriter implements ItemWriterInterface, JobExec
         );
     }
 }
-

--- a/src/batch/tests/Job/Item/Writer/LaunchJobForEachItemWriterTest.php
+++ b/src/batch/tests/Job/Item/Writer/LaunchJobForEachItemWriterTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Tests\Job\Item\Writer;
+
+use Yokai\Batch\Job\Item\Writer\LaunchJobForEachItemWriter;
+use PHPUnit\Framework\TestCase;
+use Yokai\Batch\Job\Item\Writer\LaunchJobForItemsBatchWriter;
+use Yokai\Batch\JobExecution;
+use Yokai\Batch\Test\Factory\SequenceJobExecutionIdGenerator;
+use Yokai\Batch\Test\Launcher\BufferingJobLauncher;
+
+class LaunchJobForEachItemWriterTest extends TestCase
+{
+    public function testStaticParameter(): void
+    {
+        $writer = new LaunchJobForEachItemWriter(
+            $launcher = new BufferingJobLauncher(new SequenceJobExecutionIdGenerator(['abc', 'def', 'hij', 'klm'])),
+            'test.launched_job',
+            'itemInLaunchedJob'
+        );
+
+        $writer->setJobExecution($execution = JobExecution::createRoot('123', 'test.launch_for_items_writer'));
+        $writer->write([1, 2]);
+        $writer->write([3, 4]);
+
+        $executions = $launcher->getExecutions();
+        self::assertCount(4, $executions);
+        self::assertSame('abc', $executions[0]->getId());
+        self::assertSame('test.launched_job', $executions[0]->getJobName());
+        self::assertSame(1, $executions[0]->getParameters()->get('itemInLaunchedJob'));
+        self::assertSame('def', $executions[1]->getId());
+        self::assertSame('test.launched_job', $executions[1]->getJobName());
+        self::assertSame(2, $executions[1]->getParameters()->get('itemInLaunchedJob'));
+        self::assertSame('hij', $executions[2]->getId());
+        self::assertSame('test.launched_job', $executions[2]->getJobName());
+        self::assertSame(3, $executions[2]->getParameters()->get('itemInLaunchedJob'));
+        self::assertSame('klm', $executions[3]->getId());
+        self::assertSame('test.launched_job', $executions[3]->getJobName());
+        self::assertSame(4, $executions[3]->getParameters()->get('itemInLaunchedJob'));
+        self::assertStringContainsString('Triggered job for item.', (string)$execution->getLogs());
+    }
+
+    public function testClosureParameter(): void
+    {
+        $writer = new LaunchJobForEachItemWriter(
+            $launcher = new BufferingJobLauncher(new SequenceJobExecutionIdGenerator(['abc', 'def', 'hij', 'klm'])),
+            'test.launched_job',
+            fn ($item) => ['itemInLaunchedJob' => $item, 'extraParameter' => 'foo']
+        );
+
+        $writer->setJobExecution($execution = JobExecution::createRoot('123', 'test.launch_for_items_writer'));
+        $writer->write([1, 2]);
+        $writer->write([3, 4]);
+
+        $executions = $launcher->getExecutions();
+        self::assertCount(4, $executions);
+        self::assertSame('abc', $executions[0]->getId());
+        self::assertSame('test.launched_job', $executions[0]->getJobName());
+        self::assertSame(1, $executions[0]->getParameters()->get('itemInLaunchedJob'));
+        self::assertSame('foo', $executions[0]->getParameters()->get('extraParameter'));
+        self::assertSame('def', $executions[1]->getId());
+        self::assertSame('test.launched_job', $executions[1]->getJobName());
+        self::assertSame(2, $executions[1]->getParameters()->get('itemInLaunchedJob'));
+        self::assertSame('foo', $executions[1]->getParameters()->get('extraParameter'));
+        self::assertSame('hij', $executions[2]->getId());
+        self::assertSame('test.launched_job', $executions[2]->getJobName());
+        self::assertSame(3, $executions[2]->getParameters()->get('itemInLaunchedJob'));
+        self::assertSame('foo', $executions[2]->getParameters()->get('extraParameter'));
+        self::assertSame('klm', $executions[3]->getId());
+        self::assertSame('test.launched_job', $executions[3]->getJobName());
+        self::assertSame(4, $executions[3]->getParameters()->get('itemInLaunchedJob'));
+        self::assertSame('foo', $executions[3]->getParameters()->get('extraParameter'));
+        self::assertStringContainsString('Triggered job for item.', (string)$execution->getLogs());
+    }
+}

--- a/src/batch/tests/Job/Item/Writer/LaunchJobForItemsBatchWriterTest.php
+++ b/src/batch/tests/Job/Item/Writer/LaunchJobForItemsBatchWriterTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Tests\Job\Item\Writer;
+
+use Yokai\Batch\Job\Item\Writer\LaunchJobForItemsBatchWriter;
+use PHPUnit\Framework\TestCase;
+use Yokai\Batch\JobExecution;
+use Yokai\Batch\Test\Factory\SequenceJobExecutionIdGenerator;
+use Yokai\Batch\Test\Launcher\BufferingJobLauncher;
+
+class LaunchJobForItemsBatchWriterTest extends TestCase
+{
+    public function testStaticParameter(): void
+    {
+        $writer = new LaunchJobForItemsBatchWriter(
+            $launcher = new BufferingJobLauncher(new SequenceJobExecutionIdGenerator(['456', '789'])),
+            'test.launched_job',
+            'itemsInLaunchedJob'
+        );
+
+        $writer->setJobExecution($execution = JobExecution::createRoot('123', 'test.launch_for_items_writer'));
+        $writer->write([1, 2]);
+        $writer->write([3, 4]);
+
+        $executions = $launcher->getExecutions();
+        self::assertCount(2, $executions);
+        self::assertSame('456', $executions[0]->getId());
+        self::assertSame('test.launched_job', $executions[0]->getJobName());
+        self::assertSame([1, 2], $executions[0]->getParameters()->get('itemsInLaunchedJob'));
+        self::assertSame('789', $executions[1]->getId());
+        self::assertSame('test.launched_job', $executions[1]->getJobName());
+        self::assertSame([3, 4], $executions[1]->getParameters()->get('itemsInLaunchedJob'));
+        self::assertStringContainsString('Triggered job for items batch.', (string)$execution->getLogs());
+    }
+
+    public function testClosureParameter(): void
+    {
+        $writer = new LaunchJobForItemsBatchWriter(
+            $launcher = new BufferingJobLauncher(new SequenceJobExecutionIdGenerator(['456', '789'])),
+            'test.launched_job',
+            fn (iterable $items) => ['itemsInLaunchedJob' => $items, 'extraParameter' => 'foo']
+        );
+
+        $writer->setJobExecution($execution = JobExecution::createRoot('123', 'test.launch_for_items_writer'));
+        $writer->write([1, 2]);
+        $writer->write([3, 4]);
+
+        $executions = $launcher->getExecutions();
+        self::assertCount(2, $executions);
+        self::assertSame('456', $executions[0]->getId());
+        self::assertSame('test.launched_job', $executions[0]->getJobName());
+        self::assertSame([1, 2], $executions[0]->getParameters()->get('itemsInLaunchedJob'));
+        self::assertSame('foo', $executions[0]->getParameters()->get('extraParameter'));
+        self::assertSame('789', $executions[1]->getId());
+        self::assertSame('test.launched_job', $executions[1]->getJobName());
+        self::assertSame([3, 4], $executions[1]->getParameters()->get('itemsInLaunchedJob'));
+        self::assertSame('foo', $executions[1]->getParameters()->get('extraParameter'));
+        self::assertStringContainsString('Triggered job for items batch.', (string)$execution->getLogs());
+    }
+}


### PR DESCRIPTION
This might be very handy for job chaining.
If your launcher and your process supports async, you can use this for parallelization purpose.