### PR TITLE
Added some tests over markdown documentation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "phpunit/phpunit": "^9.5",
     "squizlabs/php_codesniffer": "^3.6",
     "symfony/filesystem": "^5.0|^6.0",
+    "symfony/finder": "^5.0|^6.0",
     "symfony/process": "^5.0|^6.0"
   },
   "replace": {
@@ -67,6 +68,7 @@
   },
   "autoload-dev": {
     "psr-4": {
+      "Yokai\\Batch\\Sources\\Tests\\Convention\\": "tests/convention/",
       "Yokai\\Batch\\Sources\\Tests\\Integration\\": "tests/integration/",
       "Yokai\\Batch\\Sources\\Tests\\Symfony\\App\\": "tests/symfony/src/",
       "Yokai\\Batch\\Sources\\Tests\\Symfony\\Tests\\": "tests/symfony/tests/",

--- a/src/batch/docs/domain/item-job/item-processor.md
+++ b/src/batch/docs/domain/item-job/item-processor.md
@@ -9,6 +9,8 @@ It can be any class implementing [ItemProcessorInterface](../../../src/Job/Item/
 **Built-in item processors:**
 - [ArrayMapProcessor](../../../src/Job/Item/Processor/ArrayMapProcessor.php):
   apply a callback to each element of array items.
+- [CallbackProcessor](../../../src/Job/Item/Processor/CallbackProcessor.php):
+  use a callback to transform each items.
 - [ChainProcessor](../../../src/Job/Item/Processor/ChainProcessor.php):
   chain transformation of multiple item processor, one after the other.
 - [FilterUniqueProcessor](../../../src/Job/Item/Processor/FilterUniqueProcessor.php):
@@ -23,8 +25,12 @@ It can be any class implementing [ItemProcessorInterface](../../../src/Job/Item/
   validate item and throw exception if invalid that will cause item to be skipped.
 - [DenormalizeItemProcessor (`symfony/serializer`)](https://github.com/yokai-php/batch-symfony-serializer/blob/0.x/src/DenormalizeItemProcessor.php):
   denormalize each item.
-- [NormalizeItemProcessor (`symfony/serializer`)](https://github.com/yokai-php/batch-symfony-validator/blob/0.x/src/NormalizeItemProcessor.php):
+- [NormalizeItemProcessor (`symfony/serializer`)](https://github.com/yokai-php/batch-symfony-serializer/blob/0.x/src/NormalizeItemProcessor.php):
   normalize each item.
+
+**Item processors for testing purpose:**
+- [TestDebugProcessor](../../../src/Test/Job/Item/Processor/TestDebugProcessor.php):
+  dummy item processor that you can use in your unit tests.
 
 ## On the same subject
 

--- a/src/batch/docs/domain/item-job/item-reader.md
+++ b/src/batch/docs/domain/item-job/item-reader.md
@@ -25,10 +25,16 @@ It can be any class implementing [ItemReaderInterface](../../../src/Job/Item/Ite
 **Item readers from bridges:**
 - [FlatFileReader (`box/spout`)](https://github.com/yokai-php/batch-box-spout/blob/0.x/src/Reader/FlatFileReader.php):
   read from any CSV/ODS/XLSX file.
-- [DoctrineDBALQueryReader (`doctrine/dbal`)](https://github.com/yokai-php/batch-doctrine-dbal/blob/0.x/src/DoctrineDBALQueryReader.php):
-  read execute an SQL query and iterate over results.
+- [DoctrineDBALQueryOffsetReader (`doctrine/dbal`)](https://github.com/yokai-php/batch-doctrine-dbal/blob/0.x/src/DoctrineDBALQueryOffsetReader.php):
+  read execute an SQL query and iterate over results, using a limit + offset pagination strategy.
+- [DoctrineDBALQueryCursorReader (`doctrine/dbal`)](https://github.com/yokai-php/batch-doctrine-dbal/blob/0.x/src/DoctrineDBALQueryCursorReader.php):
+  read execute an SQL query and iterate over results, using a column based cursor strategy.
 - [EntityReader (`doctrine/orm`)](https://github.com/yokai-php/batch-doctrine-orm/blob/0.x/src/EntityReader.php):
   read from any Doctrine ORM entity.
+
+**Item readers for testing purpose:**
+- [TestDebugReader](../../../src/Test/Job/Item/Reader/TestDebugReader.php):
+  dummy item reader that you can use in your unit tests.
 
 ## On the same subject
 

--- a/src/batch/docs/domain/item-job/item-writer.md
+++ b/src/batch/docs/domain/item-job/item-writer.md
@@ -38,6 +38,12 @@ It can be any class implementing [ItemWriterInterface](../../../src/Job/Item/Ite
 - [FlatFileWriter (`box/spout`)](https://github.com/yokai-php/batch-box-spout/blob/0.x/src/Writer/FlatFileWriter.php):
   write items to any CSV/ODS/XLSX file.
 
+**Item writers for testing purpose:**
+- [InMemoryWriter](../../../src/Test/Job/Item/Writer/InMemoryWriter.php):
+  write in a private var which can be accessed afterward in your tests.
+- [TestDebugWriter](../../../src/Test/Job/Item/Writer/TestDebugWriter.php):
+  dummy item writer that you can use in your unit tests.
+
 ## On the same subject
 
 - [What is an item job ?](../item-job.md)

--- a/src/batch/docs/domain/job-execution-storage.md
+++ b/src/batch/docs/domain/job-execution-storage.md
@@ -43,6 +43,10 @@ Depending on which storage you decided to use, you may also be able to:
 - [DoctrineDBALJobExecutionStorage (`doctrine/dbal`)](https://github.com/yokai-php/batch-doctrine-dbal/blob/0.x/src/DoctrineDBALJobExecutionStorage.php):
   store job executions to a relational database.
 
+**Storages for testing purpose:**
+- [InMemoryJobExecutionStorage](../../src/Test/Storage/InMemoryJobExecutionStorage.php):
+  store executions in a private var that can be accessed afterwards in your tests.
+
 ## On the same subject
 
 - [How do I create my own storage ?](../recipes/custom-job-execution-storage.md)

--- a/src/batch/docs/domain/job-launcher.md
+++ b/src/batch/docs/domain/job-launcher.md
@@ -58,6 +58,11 @@ $execution = $launcher->launch('your.job.name', ['job' => ['configuration']]);
 - [DispatchMessageJobLauncher (`symfony/messenger`)](https://github.com/yokai-php/batch-symfony-messenger/blob/0.x/src/DispatchMessageJobLauncher.php):
   execute the job via a symfony message dispatch.
 
+**Launchers for testing purpose:**
+- [BufferingJobLauncher](../../src/Test/Launcher/BufferingJobLauncher.php):
+  do not execute job, but store execution in a private var that can be accessed afterwards in your tests.
+
 ## On the same subject
 
+- [What is a job ?](job.md)
 - [What is a job execution ?](job-execution.md)

--- a/src/batch/docs/domain/job-parameter-accessor.md
+++ b/src/batch/docs/domain/job-parameter-accessor.md
@@ -1,0 +1,63 @@
+# Job parameter accessor
+
+When a job (or a component within a job) can be working with a parameterized value,
+it can rely on a [JobParameterAccessorInterface](../../src/Job/Parameters/JobParameterAccessorInterface.php)
+instance to retrieve that value.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Yokai\Batch\Job\JobInterface;
+use Yokai\Batch\Job\Parameters\JobParameterAccessorInterface;
+use Yokai\Batch\JobExecution;
+
+class FooJob implements JobInterface
+{
+    public function __construct(
+        private JobParameterAccessorInterface $path,
+    ) {
+    }
+
+    public function execute(JobExecution $jobExecution): void
+    {
+        /** @var string $path */
+        $path = $this->path->get($jobExecution);
+        // do something with $path
+    }
+}
+```
+## What types of parameter accessors exists ?
+
+**Built-in parameter accessors:**
+- [ChainParameterAccessor.php](../../src/Job/Parameters/ChainParameterAccessor.php):
+  try multiple parameter accessors, the first that is not failing is used.
+- [ClosestJobExecutionAccessor](../../src/Job/Parameters/ClosestJobExecutionAccessor.php):
+  try another parameter accessor on each job execution in hierarchy, until not failed.
+- [DefaultParameterAccessor](../../src/Job/Parameters/DefaultParameterAccessor.php):
+  try accessing parameter using another parameter accessor, use default value if failed.
+- [JobExecutionParameterAccessor](../../src/Job/Parameters/JobExecutionParameterAccessor.php):
+  extract value from job execution's [parameters](../../src/JobParameters.php).
+- [JobExecutionSummaryAccessor](../../src/Job/Parameters/JobExecutionSummaryAccessor.php):
+  extract value from job execution's [summary](../../src/Summary.php).
+- [ParentJobExecutionAccessor](../../src/Job/Parameters/ParentJobExecutionAccessor.php):
+  use another parameter accessor on job execution's parent execution.
+- [ReplaceWithVariablesParameterAccessor](../../src/Job/Parameters/ReplaceWithVariablesParameterAccessor.php):
+  use another parameter accessor to get string value, and replace variables before returning.
+- [RootJobExecutionAccessor](../../src/Job/Parameters/RootJobExecutionAccessor.php):
+  use another parameter accessor on job execution's root execution.
+- [SiblingJobExecutionAccessor](../../src/Job/Parameters/SiblingJobExecutionAccessor.php):
+  use another parameter accessor on job execution's sibling execution.
+- [StaticValueParameterAccessor](../../src/Job/Parameters/StaticValueParameterAccessor.php):
+  use static value provided at construction.
+
+**Parameter accessors from bridges:**
+- [ContainerParameterAccessor (`symfony/framework-bundle`)](https://github.com/yokai-php/batch-symfony-framework/blob/0.x/src/ContainerParameterAccessor.php):
+  use a parameter from Symfony's container.
+
+## On the same subject
+
+- [What is a job ?](job.md)
+- [When does a job execution hierarchy is created ?](job-with-children.md)
+- [What is a job execution ?](job-execution.md)

--- a/src/batch/docs/domain/job.md
+++ b/src/batch/docs/domain/job.md
@@ -35,6 +35,7 @@ The only requirement is implementing [`JobInterface`](../../src/Job/JobInterface
   ETL like, batch processing job ([documentation](item-job.md)).
 - [JobWithChildJobs](../../src/Job/JobWithChildJobs.php):
   a job that trigger other jobs ([documentation](job-with-children.md)).
+- [TriggerScheduledJobsJob](../../src/Trigger/TriggerScheduledJobsJob.php):
 
 **Jobs from bridges:**
 - [CopyFilesJob (`league/flysystem`)](https://github.com/yokai-php/batch-league-flysystem/blob/0.x/src/Job/CopyFilesJob.php):
@@ -46,3 +47,4 @@ The only requirement is implementing [`JobInterface`](../../src/Job/JobInterface
 
 - [How do I start a job ?](job-launcher.md)
 - [How do I build a batch processing job ?](item-job.md)
+- [How do I access parameters of a job ?](job-parameter-accessor.md)

--- a/tests/convention/Autoload.php
+++ b/tests/convention/Autoload.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Sources\Tests\Convention;
+
+use SplFileInfo;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * This util class allows for autoloading introspection using filesystem.
+ * It is used to discover interfaces/classes in filesystem and list some.
+ */
+final class Autoload
+{
+    /**
+     * List all FQCNs in a filesystem path.
+     *
+     * @return iterable<class-string>
+     */
+    public static function listAllFQCN(string $path): iterable
+    {
+        foreach (self::listFiles($path) as $file) {
+            yield self::getFQCN($file);
+        }
+    }
+
+    /**
+     * Return the FQCN of the class living in a file.
+     *
+     * @return class-string
+     */
+    public static function getFQCN(string $file): string
+    {
+        return self::getNamespace($file) . '\\' . self::getClassname($file);
+    }
+
+    /**
+     * List all dirs where yokai batch packages are living.
+     *
+     * @return iterable<string>
+     */
+    public static function listPackageDirs(): iterable
+    {
+        $composer = \json_decode(\file_get_contents(__DIR__ . '/../../composer.json'), true);
+
+        foreach ($composer['autoload']['psr-4'] as $dir) {
+            yield __DIR__ . '/../../' . $dir;
+        }
+    }
+
+    private static function listFiles(string $path): iterable
+    {
+        $files = Finder::create()->files()->in($path)->name('*.php');
+        /** @var SplFileInfo $file */
+        foreach ($files as $file) {
+            yield $file->getRealpath();
+        }
+    }
+
+    private static function getNamespace(string $filename): string
+    {
+        \preg_match('/namespace (.*);/', \file_get_contents($filename), $namespace);
+
+        return $namespace[1] ?? throw new \Exception('No namespace');
+    }
+
+    private static function getClassname(string $filename): string
+    {
+        return \basename($filename, '.php');
+    }
+
+}

--- a/tests/convention/Autoload.php
+++ b/tests/convention/Autoload.php
@@ -69,5 +69,4 @@ final class Autoload
     {
         return \basename($filename, '.php');
     }
-
 }

--- a/tests/convention/Documentation/DocFile.php
+++ b/tests/convention/Documentation/DocFile.php
@@ -15,9 +15,9 @@ final class DocFile
         public string $package,
         public SplFileInfo $file,
         /**
-         * @var iterable<DocLink>
+         * @var array<DocLink>
          */
-        public iterable $links,
+        public array $links,
     ) {
     }
 }

--- a/tests/convention/Documentation/DocFile.php
+++ b/tests/convention/Documentation/DocFile.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Sources\Tests\Convention\Documentation;
+
+use SplFileInfo;
+
+final class DocFile
+{
+    public function __construct(
+        public string $package,
+        public SplFileInfo $file,
+    ) {
+    }
+}

--- a/tests/convention/Documentation/DocFile.php
+++ b/tests/convention/Documentation/DocFile.php
@@ -6,11 +6,18 @@ namespace Yokai\Batch\Sources\Tests\Convention\Documentation;
 
 use SplFileInfo;
 
+/**
+ * A Markdown documentation file.
+ */
 final class DocFile
 {
     public function __construct(
         public string $package,
         public SplFileInfo $file,
+        /**
+         * @var iterable<DocLink>
+         */
+        public iterable $links,
     ) {
     }
 }

--- a/tests/convention/Documentation/DocLink.php
+++ b/tests/convention/Documentation/DocLink.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Sources\Tests\Convention\Documentation;
+
+use SplFileInfo;
+
+final class DocLink
+{
+    public function __construct(
+        public DocFile $file,
+        public string $label,
+        public string $package,
+        public string $uri,
+        public SplFileInfo $pointsToFile,
+        public string $branch,
+        public bool $absolute,
+    ) {
+    }
+}

--- a/tests/convention/Documentation/DocLink.php
+++ b/tests/convention/Documentation/DocLink.php
@@ -6,10 +6,12 @@ namespace Yokai\Batch\Sources\Tests\Convention\Documentation;
 
 use SplFileInfo;
 
+/**
+ * A markdown link in a markdown documentation file.
+ */
 final class DocLink
 {
     public function __construct(
-        public DocFile $file,
         public string $label,
         public string $package,
         public string $uri,

--- a/tests/convention/Documentation/Markdown.php
+++ b/tests/convention/Documentation/Markdown.php
@@ -7,6 +7,11 @@ namespace Yokai\Batch\Sources\Tests\Convention\Documentation;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
 
+/**
+ * This util class is a wrapper around Symfony's finder.
+ * It will search for markdown files considered as documentation.
+ * Every fetched files will be converted to a {@see DocFile}.
+ */
 final class Markdown
 {
     private const MARKDOWN_LINKS_REGEX = '/\[([^]]+)\]\(([^)]+)\)/';
@@ -15,6 +20,8 @@ final class Markdown
     private const ROOT_DIR = __DIR__ . '/../../..';
 
     /**
+     * List every known markdown documentation files in yokai batch packages.
+     *
      * @return iterable<DocFile>
      */
     public static function listFiles(): iterable
@@ -22,20 +29,31 @@ final class Markdown
         $files = Finder::create()->files()->in(self::ROOT_DIR . '/src/*/')->name('*.md');
 
         foreach ($files as $file) {
-            yield new DocFile(self::getPackageFromFile($file), $file);
+            yield self::createDocFile($file);
         }
     }
 
+    /**
+     * Convert a markdown documentation file to a {@see DocFile}.
+     */
     public static function getFile(string $path): DocFile
     {
-        $file = new SplFileInfo(self::ROOT_DIR . '/src/' . \ltrim($path, '/'));
-
-        return new DocFile(self::getPackageFromFile($file), $file);
+        return self::createDocFile(new SplFileInfo(self::ROOT_DIR . '/src/' . \ltrim($path, '/')));
     }
 
-    public static function listLinksInFile(DocFile $file): iterable
+    private static function createDocFile(SplFileInfo $file): DocFile
     {
-        \preg_match_all(self::MARKDOWN_LINKS_REGEX, \file_get_contents($file->file->getRealPath()), $fileLinks);
+        $package = self::getPackageFromFile($file);
+
+        return new DocFile($package, $file, self::listLinksInFile($file->getRealPath(), $package));
+    }
+
+    /**
+     * @return iterable<DocLink>
+     */
+    private static function listLinksInFile(string $path, string $filePackage): iterable
+    {
+        \preg_match_all(self::MARKDOWN_LINKS_REGEX, \file_get_contents($path), $fileLinks);
         foreach (\array_keys($fileLinks[0]) as $idx) {
             $label = $fileLinks[1][$idx];
             $uri = $fileLinks[2][$idx];
@@ -50,25 +68,25 @@ final class Markdown
                 }
                 [, $package, $branch, $linkPath] = $internalLink;
             } else {
-                $package = $file->package;
+                $package = $filePackage;
                 $branch = self::DEFAULT_BRANCH;
                 $linkPath = $uri;
             }
 
             $linkFile = self::getFileFromMembers($package, $linkPath);
 
-            yield new DocLink($file, $label, $package, $uri, $linkFile, $branch, $absolute);
+            yield new DocLink($label, $package, $uri, $linkFile, $branch, $absolute);
         }
     }
 
-    public static function getPackageFromFile(SplFileInfo $file): string
+    private static function getPackageFromFile(SplFileInfo $file): string
     {
         $relativePath = \str_replace(\realpath(self::ROOT_DIR) . '/src/', '', $file->getRealPath());
 
         return \dirname($relativePath);
     }
 
-    public static function getFileFromMembers(string $package, string $file): SplFileInfo
+    private static function getFileFromMembers(string $package, string $file): SplFileInfo
     {
         return new SplFileInfo(self::ROOT_DIR . '/src/' . $package . '/' . \ltrim($file, '/'));
     }

--- a/tests/convention/Documentation/Markdown.php
+++ b/tests/convention/Documentation/Markdown.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Sources\Tests\Convention\Documentation;
+
+use SplFileInfo;
+use Symfony\Component\Finder\Finder;
+
+final class Markdown
+{
+    private const MARKDOWN_LINKS_REGEX = '/\[([^]]+)\]\(([^)]+)\)/';
+    private const GITHUB_BATCH_LINK_REGEX = '#https\:\/\/github\.com\/yokai\-php\/([^/]+)\/blob\/([^/]+)\/(.+)#';
+    private const DEFAULT_BRANCH = '0.x';
+    private const ROOT_DIR = __DIR__ . '/../../..';
+
+    /**
+     * @return iterable<DocFile>
+     */
+    public static function listFiles(): iterable
+    {
+        $files = Finder::create()->files()->in(self::ROOT_DIR . '/src/*/')->name('*.md');
+
+        foreach ($files as $file) {
+            yield new DocFile(self::getPackageFromFile($file), $file);
+        }
+    }
+
+    public static function getFile(string $path): DocFile
+    {
+        $file = new SplFileInfo(self::ROOT_DIR . '/src/' . \ltrim($path, '/'));
+
+        return new DocFile(self::getPackageFromFile($file), $file);
+    }
+
+    public static function listLinksInFile(DocFile $file): iterable
+    {
+        \preg_match_all(self::MARKDOWN_LINKS_REGEX, \file_get_contents($file->file->getRealPath()), $fileLinks);
+        foreach (\array_keys($fileLinks[0]) as $idx) {
+            $label = $fileLinks[1][$idx];
+            $uri = $fileLinks[2][$idx];
+            if (\str_starts_with($label, '!')) {
+                continue; // it's an image
+            }
+
+            $absolute = \str_starts_with($uri, 'https://') || \str_starts_with($uri, 'http://');
+            if ($absolute) {
+                if (!\preg_match(self::GITHUB_BATCH_LINK_REGEX, $uri, $internalLink)) {
+                    continue; // it's an external link
+                }
+                [, $package, $branch, $linkPath] = $internalLink;
+            } else {
+                $package = $file->package;
+                $branch = self::DEFAULT_BRANCH;
+                $linkPath = $uri;
+            }
+
+            $linkFile = self::getFileFromMembers($package, $linkPath);
+
+            yield new DocLink($file, $label, $package, $uri, $linkFile, $branch, $absolute);
+        }
+    }
+
+    public static function getPackageFromFile(SplFileInfo $file): string
+    {
+        $relativePath = \str_replace(\realpath(self::ROOT_DIR) . '/src/', '', $file->getRealPath());
+
+        return \dirname($relativePath);
+    }
+
+    public static function getFileFromMembers(string $package, string $file): SplFileInfo
+    {
+        return new SplFileInfo(self::ROOT_DIR . '/src/' . $package . '/' . \ltrim($file, '/'));
+    }
+}

--- a/tests/convention/Documentation/Markdown.php
+++ b/tests/convention/Documentation/Markdown.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yokai\Batch\Sources\Tests\Convention\Documentation;
 
+use Generator;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
 
@@ -44,14 +45,15 @@ final class Markdown
     private static function createDocFile(SplFileInfo $file): DocFile
     {
         $package = self::getPackageFromFile($file);
+        $links = \iterator_to_array(self::listLinksInFile($file->getRealPath(), $package));
 
-        return new DocFile($package, $file, self::listLinksInFile($file->getRealPath(), $package));
+        return new DocFile($package, $file, $links);
     }
 
     /**
-     * @return iterable<DocLink>
+     * @return Generator<DocLink>
      */
-    private static function listLinksInFile(string $path, string $filePackage): iterable
+    private static function listLinksInFile(string $path, string $filePackage): Generator
     {
         \preg_match_all(self::MARKDOWN_LINKS_REGEX, \file_get_contents($path), $fileLinks);
         foreach (\array_keys($fileLinks[0]) as $idx) {

--- a/tests/convention/Documentation/MarkdownLinksTest.php
+++ b/tests/convention/Documentation/MarkdownLinksTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Sources\Tests\Convention\Documentation;
+
+use PHPUnit\Framework\TestCase;
+use Yokai\Batch\Job\Item\ItemProcessorInterface;
+use Yokai\Batch\Job\Item\ItemReaderInterface;
+use Yokai\Batch\Job\Item\ItemWriterInterface;
+use Yokai\Batch\Job\JobInterface;
+use Yokai\Batch\Job\Parameters\JobParameterAccessorInterface;
+use Yokai\Batch\Launcher\JobLauncherInterface;
+use Yokai\Batch\Sources\Tests\Convention\Autoload;
+use Yokai\Batch\Storage\JobExecutionStorageInterface;
+
+/**
+ * Some assertions on markdown documentation files.
+ */
+final class MarkdownLinksTest extends TestCase
+{
+    private const DEFAULT_BRANCH = '0.x';
+
+    /**
+     * Ensure that all links in markdown files points to valid interal resources.
+     */
+    public function testInternalLinksAreValid(): void
+    {
+        /** @var DocFile $file */
+        foreach (Markdown::listFiles() as $file) {
+            foreach (Markdown::listLinksInFile($file) as $link) {
+                if ($link->package !== $file->package) {
+                    self::assertTrue($link->absolute, 'When pointing to another package, links must be absolute.');
+                }
+
+                self::assertNotFalse(
+                    $link->pointsToFile->getRealPath(),
+                    "Link \"{$link->label}\" in \"{$link->pointsToFile->getRealPath()}\"," .
+                    " is pointing to \"{$link->uri}\" which reference an internal file that do not exists."
+                );
+
+                self::assertSame(self::DEFAULT_BRANCH, $link->branch, 'All links must be wired on default branch.');
+            }
+        }
+    }
+
+    /**
+     * Ensure that all implementations of some yokai batch interfaces are listed in certain files.
+     */
+    public function testComponentsAreListed(): void
+    {
+        // All rules of components listing must be defined here
+        $rules = [
+            'batch/docs/domain/job.md' => JobInterface::class,
+            'batch/docs/domain/job-execution-storage.md' => JobExecutionStorageInterface::class,
+            'batch/docs/domain/job-launcher.md' => JobLauncherInterface::class,
+            'batch/docs/domain/job-parameter-accessor.md' => JobParameterAccessorInterface::class,
+            'batch/docs/domain/item-job/item-reader.md' => ItemReaderInterface::class,
+            'batch/docs/domain/item-job/item-processor.md' => ItemProcessorInterface::class,
+            'batch/docs/domain/item-job/item-writer.md' => ItemWriterInterface::class,
+        ];
+
+        $actualClassesForInterface = $expectedClassesForInterface = \array_fill_keys($rules, []);
+
+        // Find all classes in libraries that implement these interfaces
+        foreach (Autoload::listPackageDirs() as $dir) {
+            foreach (Autoload::listAllFQCN($dir) as $class) {
+                foreach ($rules as $interface) {
+                    if ($class !== $interface && \is_a($class, $interface, true)) {
+                        $expectedClassesForInterface[$interface][] = $class;
+                    }
+                }
+            }
+        }
+
+        // Find all links in these files that points to file that implement these interfaces
+        foreach ($rules as $filepath => $interface) {
+            $file = Markdown::getFile($filepath);
+            foreach (Markdown::listLinksInFile($file) as $link) {
+                if (!\str_ends_with($link->uri, '.php')) {
+                    continue; // it's not a php file the link is pointing to
+                }
+                $class = Autoload::getFQCN($link->pointsToFile->getRealPath());
+                if ($class !== $interface && \is_a($class, $interface, true)) {
+                    $actualClassesForInterface[$interface][] = $class;
+                }
+            }
+        }
+
+        // Classes are sorted before being compared
+        foreach ($expectedClassesForInterface as &$classes) {
+            \sort($classes);
+        }
+        foreach ($actualClassesForInterface as &$classes) {
+            \sort($classes);
+        }
+
+        // Compare classes implementing these interfaces with listed classes in file
+        foreach ($rules as $file => $interface) {
+            self::assertSame(
+                $expectedClassesForInterface[$interface],
+                $actualClassesForInterface[$interface],
+                "All classes implementing \"{$interface}\" should be linked in \"{$file}\"."
+            );
+        }
+    }
+}

--- a/tests/convention/Documentation/MarkdownLinksTest.php
+++ b/tests/convention/Documentation/MarkdownLinksTest.php
@@ -22,88 +22,112 @@ final class MarkdownLinksTest extends TestCase
     private const DEFAULT_BRANCH = '0.x';
 
     /**
-     * Ensure that all links in markdown files points to valid interal resources.
+     * Ensure that all links in markdown files points to valid internal resources.
+     *
+     * @dataProvider filesWithLinks
      */
-    public function testInternalLinksAreValid(): void
+    public function testInternalLinksAreValid(DocFile $file): void
+    {
+        /** @var DocLink $link */
+        foreach ($file->links as $link) {
+            if ($link->package !== $file->package) {
+                self::assertTrue($link->absolute, 'When pointing to another package, links must be absolute.');
+            }
+
+            self::assertNotFalse(
+                $link->pointsToFile->getRealPath(),
+                "Link \"{$link->label}\" in \"{$link->pointsToFile->getRealPath()}\"," .
+                " is pointing to \"{$link->uri}\" which reference an internal file that do not exists."
+            );
+
+            self::assertSame(self::DEFAULT_BRANCH, $link->branch, 'All links must be wired on default branch.');
+        }
+    }
+
+    public function filesWithLinks(): iterable
     {
         /** @var DocFile $file */
         foreach (Markdown::listFiles() as $file) {
-            /** @var DocLink $link */
-            foreach ($file->links as $link) {
-                if ($link->package !== $file->package) {
-                    self::assertTrue($link->absolute, 'When pointing to another package, links must be absolute.');
-                }
-
-                self::assertNotFalse(
-                    $link->pointsToFile->getRealPath(),
-                    "Link \"{$link->label}\" in \"{$link->pointsToFile->getRealPath()}\"," .
-                    " is pointing to \"{$link->uri}\" which reference an internal file that do not exists."
-                );
-
-                self::assertSame(self::DEFAULT_BRANCH, $link->branch, 'All links must be wired on default branch.');
+            if (\count($file->links) === 0) {
+                continue;
             }
+            yield $file->file->getRealPath() => [$file];
         }
     }
 
     /**
      * Ensure that all implementations of some yokai batch interfaces are listed in certain files.
+     *
+     * @dataProvider interfaceRules
      */
-    public function testComponentsAreListed(): void
+    public function testComponentsAreListed(string $filepath, string $interface): void
     {
-        // All rules of components listing must be defined here
-        $rules = [
-            'batch/docs/domain/job.md' => JobInterface::class,
-            'batch/docs/domain/job-execution-storage.md' => JobExecutionStorageInterface::class,
-            'batch/docs/domain/job-launcher.md' => JobLauncherInterface::class,
-            'batch/docs/domain/job-parameter-accessor.md' => JobParameterAccessorInterface::class,
-            'batch/docs/domain/item-job/item-reader.md' => ItemReaderInterface::class,
-            'batch/docs/domain/item-job/item-processor.md' => ItemProcessorInterface::class,
-            'batch/docs/domain/item-job/item-writer.md' => ItemWriterInterface::class,
-        ];
+        $expectedClasses = [];
+        $actualClasses = [];
 
-        $actualClassesForInterface = $expectedClassesForInterface = \array_fill_keys($rules, []);
-
-        // Find all classes in libraries that implement these interfaces
+        // Find all classes in libraries that implement this interface
         foreach (Autoload::listPackageDirs() as $dir) {
             foreach (Autoload::listAllFQCN($dir) as $class) {
-                foreach ($rules as $interface) {
-                    if ($class !== $interface && \is_a($class, $interface, true)) {
-                        $expectedClassesForInterface[$interface][] = $class;
-                    }
+                if ($class !== $interface && \is_a($class, $interface, true)) {
+                    $expectedClasses[] = $class;
                 }
             }
         }
 
         // Find all links in these files that points to file that implement these interfaces
-        foreach ($rules as $filepath => $interface) {
-            $file = Markdown::getFile($filepath);
-            /** @var DocLink $link */
-            foreach ($file->links as $link) {
-                if (!\str_ends_with($link->uri, '.php')) {
-                    continue; // it's not a php file the link is pointing to
-                }
-                $class = Autoload::getFQCN($link->pointsToFile->getRealPath());
-                if ($class !== $interface && \is_a($class, $interface, true)) {
-                    $actualClassesForInterface[$interface][] = $class;
-                }
+        $file = Markdown::getFile($filepath);
+        /** @var DocLink $link */
+        foreach ($file->links as $link) {
+            if (!\str_ends_with($link->uri, '.php')) {
+                continue; // it's not a php file the link is pointing to
+            }
+            $class = Autoload::getFQCN($link->pointsToFile->getRealPath());
+            if ($class !== $interface && \is_a($class, $interface, true)) {
+                $actualClasses[] = $class;
             }
         }
 
         // Classes are sorted before being compared
-        foreach ($expectedClassesForInterface as &$classes) {
-            \sort($classes);
-        }
-        foreach ($actualClassesForInterface as &$classes) {
-            \sort($classes);
-        }
+        \sort($expectedClasses);
+        \sort($actualClasses);
 
         // Compare classes implementing these interfaces with listed classes in file
-        foreach ($rules as $file => $interface) {
-            self::assertSame(
-                $expectedClassesForInterface[$interface],
-                $actualClassesForInterface[$interface],
-                "All classes implementing \"{$interface}\" should be linked in \"{$file}\"."
-            );
-        }
+        self::assertSame(
+            $expectedClasses,
+            $actualClasses,
+            "All classes implementing \"{$interface}\" should be linked in \"{$filepath}\"."
+        );
+    }
+
+    public function interfaceRules(): iterable
+    {
+        yield 'JobInterface' => [
+            'batch/docs/domain/job.md',
+            JobInterface::class,
+        ];
+        yield 'JobExecutionStorageInterface' => [
+            'batch/docs/domain/job-execution-storage.md',
+            JobExecutionStorageInterface::class,
+        ];
+        yield 'JobLauncherInterface' => [
+            'batch/docs/domain/job-launcher.md',
+            JobLauncherInterface::class,
+        ];
+        yield 'JobParameterAccessorInterface' => [
+            'batch/docs/domain/job-parameter-accessor.md',
+            JobParameterAccessorInterface::class,
+        ];
+        yield 'ItemReaderInterface' => [
+            'batch/docs/domain/item-job/item-reader.md',
+            ItemReaderInterface::class,
+        ];
+        yield 'ItemProcessorInterface' => [
+            'batch/docs/domain/item-job/item-processor.md',
+            ItemProcessorInterface::class,
+        ];
+        yield 'ItemWriterInterface' => [
+            'batch/docs/domain/item-job/item-writer.md',
+            ItemWriterInterface::class,
+        ];
     }
 }

--- a/tests/convention/Documentation/MarkdownLinksTest.php
+++ b/tests/convention/Documentation/MarkdownLinksTest.php
@@ -28,7 +28,8 @@ final class MarkdownLinksTest extends TestCase
     {
         /** @var DocFile $file */
         foreach (Markdown::listFiles() as $file) {
-            foreach (Markdown::listLinksInFile($file) as $link) {
+            /** @var DocLink $link */
+            foreach ($file->links as $link) {
                 if ($link->package !== $file->package) {
                     self::assertTrue($link->absolute, 'When pointing to another package, links must be absolute.');
                 }
@@ -76,7 +77,8 @@ final class MarkdownLinksTest extends TestCase
         // Find all links in these files that points to file that implement these interfaces
         foreach ($rules as $filepath => $interface) {
             $file = Markdown::getFile($filepath);
-            foreach (Markdown::listLinksInFile($file) as $link) {
+            /** @var DocLink $link */
+            foreach ($file->links as $link) {
                 if (!\str_ends_with($link->uri, '.php')) {
                     continue; // it's not a php file the link is pointing to
                 }

--- a/tests/integration/ImportDevelopersXlsxToORMTest.php
+++ b/tests/integration/ImportDevelopersXlsxToORMTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Yokai\Batch\Sources\Tests\Integration;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Tools\SchemaTool;
-use Doctrine\ORM\Tools\Setup;
 use Doctrine\Persistence\ManagerRegistry;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -55,7 +55,7 @@ class ImportDevelopersXlsxToORMTest extends JobTestCase
     {
         $this->persisted = [];
 
-        $config = Setup::createAnnotationMetadataConfiguration([__DIR__ . '/Entity'], true, null, null, false);
+        $config = ORMSetup::createAnnotationMetadataConfiguration([__DIR__ . '/Entity'], true);
         $this->entityManager = EntityManager::create(['url' => getenv('DATABASE_URL')], $config);
 
         (new SchemaTool($this->entityManager))


### PR DESCRIPTION
Documentation is a must have for such library.
But if writing doc is hard, maintaining doc is much harder, because we forget to do so.

The goal of this PR is to allow some automated tools to perform some checks over the produced documentation.

So far, I identified 2 things I usually forget :
- a class is renamed or removed, but somewhere a link is still pointing to it
- a new implementation of an interface is produced, and a link to that implementation is missing

This PR introduce a test for both cases.