### PR TITLE
Run coverage only when everything else succeed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,7 @@ jobs:
 
   codecov:
     name: "Code coverage"
+    needs: [phpunit, phpstan, checkstyke, conventions]
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"


### PR DESCRIPTION
![image](https://github.com/yokai-php/batch-src/assets/1303838/922b77fa-ef17-46cf-9a78-d1e82858541f)

Coverage is essentially a test suite that already has been executed.
If the tests are failing, there is no reason for the coverage to be executed.