### PR TITLE
Quote versions in YAML files to avoid interpretation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,14 +13,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - php-version: 8.0
-            symfony-version: 5.4.*
-          - php-version: 8.0
-            symfony-version: 6.0.*
-          - php-version: 8.2
-            symfony-version: 5.4.*
-          - php-version: 8.2
-            symfony-version: 6.2.*
+          - php-version: '8.0'
+            symfony-version: '5.4.*'
+          - php-version: '8.0'
+            symfony-version: '6.0.*'
+          - php-version: '8.2'
+            symfony-version: '5.4.*'
+          - php-version: '8.2'
+            symfony-version: '6.2.*'
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2


### PR DESCRIPTION
Because YAML converts `8.0` to `8`
But we want actual `8.0`

![image](https://github.com/yokai-php/batch-src/assets/1303838/c7c52c44-84dd-4c25-80ec-d49da943bda3) ![image](https://github.com/yokai-php/batch-src/assets/1303838/a669c3ff-55ed-4ee9-b4b9-c2765992e4c0)
