### PR TITLE
Remove batch-box-spout from synchronized packages

### DIFF
--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -31,7 +31,6 @@ see https://github.com/yokai-php/batch-src/releases/tag/{created tag}
 ```
 - Create a release for the tag, in each packages
   - https://github.com/yokai-php/batch/releases/new
-  - https://github.com/yokai-php/batch-box-spout/releases/new
   - https://github.com/yokai-php/batch-doctrine-dbal/releases/new
   - https://github.com/yokai-php/batch-doctrine-orm/releases/new
   - https://github.com/yokai-php/batch-doctrine-persistence/releases/new

--- a/scripts/split-branch
+++ b/scripts/split-branch
@@ -25,7 +25,6 @@ function remote()
 }
 
 remote batch                      git@github.com:yokai-php/batch.git
-remote batch-box-spout            git@github.com:yokai-php/batch-box-spout.git
 remote batch-doctrine-dbal        git@github.com:yokai-php/batch-doctrine-dbal.git
 remote batch-doctrine-orm         git@github.com:yokai-php/batch-doctrine-orm.git
 remote batch-doctrine-persistence git@github.com:yokai-php/batch-doctrine-persistence.git
@@ -39,7 +38,6 @@ remote batch-symfony-serializer   git@github.com:yokai-php/batch-symfony-seriali
 remote batch-symfony-validator    git@github.com:yokai-php/batch-symfony-validator.git
 
 split 'src/batch'                      batch
-split 'src/batch-box-spout'            batch-box-spout
 split 'src/batch-doctrine-dbal'        batch-doctrine-dbal
 split 'src/batch-doctrine-orm'         batch-doctrine-orm
 split 'src/batch-doctrine-persistence' batch-doctrine-persistence

--- a/scripts/split-tag
+++ b/scripts/split-tag
@@ -25,7 +25,6 @@ function remote()
 }
 
 remote batch                      git@github.com:yokai-php/batch.git
-remote batch-box-spout            git@github.com:yokai-php/batch-box-spout.git
 remote batch-doctrine-dbal        git@github.com:yokai-php/batch-doctrine-dbal.git
 remote batch-doctrine-orm         git@github.com:yokai-php/batch-doctrine-orm.git
 remote batch-doctrine-persistence git@github.com:yokai-php/batch-doctrine-persistence.git
@@ -39,7 +38,6 @@ remote batch-symfony-serializer   git@github.com:yokai-php/batch-symfony-seriali
 remote batch-symfony-validator    git@github.com:yokai-php/batch-symfony-validator.git
 
 split 'src/batch'                      batch
-split 'src/batch-box-spout'            batch-box-spout
 split 'src/batch-doctrine-dbal'        batch-doctrine-dbal
 split 'src/batch-doctrine-orm'         batch-doctrine-orm
 split 'src/batch-doctrine-persistence' batch-doctrine-persistence


### PR DESCRIPTION
Because the package was replaced and the repository archived, we cannot sync it anymore