### PR TITLE
Add a component to build JobParameters defaults at contruction time

### DIFF
--- a/src/batch-symfony-console/tests/RunCommandJobLauncherTest.php
+++ b/src/batch-symfony-console/tests/RunCommandJobLauncherTest.php
@@ -11,6 +11,7 @@ use Yokai\Batch\BatchStatus;
 use Yokai\Batch\Bridge\Symfony\Console\CommandRunner;
 use Yokai\Batch\Bridge\Symfony\Console\RunCommandJobLauncher;
 use Yokai\Batch\Factory\JobExecutionFactory;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\NullJobExecutionParametersBuilder;
 use Yokai\Batch\Factory\UniqidJobExecutionIdGenerator;
 use Yokai\Batch\Test\Storage\InMemoryJobExecutionStorage;
 
@@ -29,7 +30,7 @@ class RunCommandJobLauncherTest extends TestCase
             ->shouldBeCalledTimes(1);
 
         $launcher = new RunCommandJobLauncher(
-            new JobExecutionFactory(new UniqidJobExecutionIdGenerator()),
+            new JobExecutionFactory(new UniqidJobExecutionIdGenerator(), new NullJobExecutionParametersBuilder()),
             $commandRunner->reveal(),
             $storage = new InMemoryJobExecutionStorage(),
             'test.log'

--- a/src/batch-symfony-console/tests/RunJobCommandTest.php
+++ b/src/batch-symfony-console/tests/RunJobCommandTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Yokai\Batch\Bridge\Symfony\Console\RunJobCommand;
 use Yokai\Batch\Exception\UnexpectedValueException;
 use Yokai\Batch\Factory\JobExecutionFactory;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\NullJobExecutionParametersBuilder;
 use Yokai\Batch\Factory\UniqidJobExecutionIdGenerator;
 use Yokai\Batch\Job\JobExecutionAccessor;
 use Yokai\Batch\Job\JobExecutor;
@@ -38,7 +39,7 @@ class RunJobCommandTest extends TestCase
         $this->job = $this->prophesize(JobInterface::class);
 
         $this->accessor = new JobExecutionAccessor(
-            new JobExecutionFactory(new UniqidJobExecutionIdGenerator()),
+            new JobExecutionFactory(new UniqidJobExecutionIdGenerator(), new NullJobExecutionParametersBuilder()),
             new InMemoryJobExecutionStorage(),
         );
         $this->executor = new JobExecutor(

--- a/src/batch-symfony-framework/src/DependencyInjection/Configuration.php
+++ b/src/batch-symfony-framework/src/DependencyInjection/Configuration.php
@@ -162,6 +162,7 @@ final class Configuration implements ConfigurationInterface
                 ->arrayNode('global')
                     ->useAttributeAsKey('name')
                     ->variablePrototype()
+                    ->end()
                 ->end()
                 ->arrayNode('per_job')
                     ->useAttributeAsKey('name')
@@ -169,6 +170,7 @@ final class Configuration implements ConfigurationInterface
                     ->validate()
                         ->ifTrue(fn(mixed $value) => !$isStringAssociativeArray($value))
                             ->thenInvalid('Should be an array<string, mixed>')
+                    ->end()
                 ->end()
             ->end()
         ;

--- a/src/batch-symfony-framework/src/DependencyInjection/Configuration.php
+++ b/src/batch-symfony-framework/src/DependencyInjection/Configuration.php
@@ -169,7 +169,7 @@ final class Configuration implements ConfigurationInterface
                     ->variablePrototype()
                     ->validate()
                         ->ifTrue(fn(mixed $value) => !$isStringAssociativeArray($value))
-                            ->thenInvalid('Should be an array<string, mixed>')
+                            ->thenInvalid('Should be an array<string, mixed>.')
                     ->end()
                 ->end()
             ->end()

--- a/src/batch-symfony-framework/src/DependencyInjection/Configuration.php
+++ b/src/batch-symfony-framework/src/DependencyInjection/Configuration.php
@@ -14,6 +14,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  * @phpstan-type Config array{
  *      storage: StorageConfig,
  *      launcher: LauncherConfig,
+ *      parameters: ParametersConfig,
  *      ui: UserInterfaceConfig,
  *  }
  * @phpstan-type StorageConfig array{
@@ -30,6 +31,10 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  * @phpstan-type LauncherConfig array{
  *      default: string|null,
  *      launchers: array<string, string>,
+ *  }
+ * @phpstan-type ParametersConfig array{
+ *      global: array<string, mixed>,
+ *      per_job: array<string, array<string, mixed>>,
  *  }
  * @phpstan-type UserInterfaceConfig array{
  *      enabled: bool,
@@ -59,6 +64,7 @@ final class Configuration implements ConfigurationInterface
             ->children()
                 ->append($this->storage())
                 ->append($this->launcher())
+                ->append($this->parameters())
                 ->append($this->ui())
             ->end()
         ;
@@ -124,6 +130,45 @@ final class Configuration implements ConfigurationInterface
                     ->validate()
                         ->ifTrue($isInvalidDsn)->thenInvalid('Invalid job launcher DSN.')
                     ->end()
+                ->end()
+            ->end()
+        ;
+
+        return $node;
+    }
+
+    private function parameters(): ArrayNodeDefinition
+    {
+        /** @var ArrayNodeDefinition $node */
+        $node = (new TreeBuilder('parameters'))->getRootNode();
+
+        $isStringAssociativeArray = function (mixed $value): bool {
+            if (!\is_array($value)) {
+                return false;
+            }
+
+            foreach ($value as $key => $unused) {
+                if (!\is_string($key)) {
+                    return false;
+                }
+            }
+
+            return true;
+        };
+
+        $node
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->arrayNode('global')
+                    ->useAttributeAsKey('name')
+                    ->variablePrototype()
+                ->end()
+                ->arrayNode('per_job')
+                    ->useAttributeAsKey('name')
+                    ->variablePrototype()
+                    ->validate()
+                        ->ifTrue(fn(mixed $value) => !$isStringAssociativeArray($value))
+                            ->thenInvalid('Should be an array<string, mixed>')
                 ->end()
             ->end()
         ;

--- a/src/batch-symfony-framework/src/DependencyInjection/YokaiBatchExtension.php
+++ b/src/batch-symfony-framework/src/DependencyInjection/YokaiBatchExtension.php
@@ -22,6 +22,8 @@ use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Form\JobFilterType;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Templating\ConfigurableTemplating;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Templating\SonataAdminTemplating;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Templating\TemplatingInterface;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\PerJobJobExecutionParametersBuilder;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\StaticJobExecutionParametersBuilder;
 use Yokai\Batch\Launcher\JobLauncherInterface;
 use Yokai\Batch\Storage\FilesystemJobExecutionStorage;
 use Yokai\Batch\Storage\JobExecutionStorageInterface;
@@ -34,6 +36,7 @@ use Yokai\Batch\Storage\QueryableJobExecutionStorageInterface;
  * @phpstan-import-type Config from Configuration
  * @phpstan-import-type StorageConfig from Configuration
  * @phpstan-import-type LauncherConfig from Configuration
+ * @phpstan-import-type ParametersConfig from Configuration
  * @phpstan-import-type UserInterfaceConfig from Configuration
  */
 final class YokaiBatchExtension extends Extension
@@ -64,6 +67,7 @@ final class YokaiBatchExtension extends Extension
 
         $this->configureStorage($container, $config['storage']);
         $this->configureLauncher($container, $config['launcher']);
+        $this->configureParameters($container, $config['parameters']);
         $this->configureUserInterface($container, $loader, $config['ui']);
 
         $container->registerAliasForArgument('yokai_batch.logger', LoggerInterface::class, 'yokaiBatchLogger');
@@ -187,6 +191,25 @@ final class YokaiBatchExtension extends Extension
             JobLauncherInterface::class,
             'yokai_batch.job_launcher.' . $config['default'],
         );
+    }
+
+    /**
+     * @param ParametersConfig $config
+     */
+    private function configureParameters(ContainerBuilder $container, array $config): void
+    {
+        if ($config['global'] !== []) {
+            $container->register('yokai_batch.job_execution_parameters_builder.global')
+                ->setClass(StaticJobExecutionParametersBuilder::class)
+                ->setArgument('$parameters', $config['global'])
+                ->addTag('yokai_batch.job_execution_parameters_builder');
+        }
+        if ($config['per_job'] !== []) {
+            $container->register('yokai_batch.job_execution_parameters_builder.per_job')
+                ->setClass(PerJobJobExecutionParametersBuilder::class)
+                ->setArgument('$perJobParameters', $config['per_job'])
+                ->addTag('yokai_batch.job_execution_parameters_builder');
+        }
     }
 
     /**

--- a/src/batch-symfony-framework/src/Resources/services/global/alias.xml
+++ b/src/batch-symfony-framework/src/Resources/services/global/alias.xml
@@ -21,5 +21,8 @@
 
         <service id="Yokai\Batch\Factory\JobExecutionIdGeneratorInterface"
                  alias="yokai_batch.job_execution_id_generator.uniqid"/>
+
+        <service id="Yokai\Batch\Factory\JobExecutionParametersBuilderInterface"
+                 alias="yokai_batch.job_execution_parameters_builder.chain"/>
     </services>
 </container>

--- a/src/batch-symfony-framework/src/Resources/services/global/core.xml
+++ b/src/batch-symfony-framework/src/Resources/services/global/core.xml
@@ -10,6 +10,7 @@
         <service id="yokai_batch.job_execution_factory"
                  class="Yokai\Batch\Factory\JobExecutionFactory">
             <argument type="service" id="Yokai\Batch\Factory\JobExecutionIdGeneratorInterface"/>
+            <argument type="service" id="Yokai\Batch\Factory\JobExecutionParametersBuilderInterface"/>
         </service>
 
         <service id="yokai_batch.job_registry"
@@ -32,5 +33,10 @@
 
         <service id="yokai_batch.job_execution_id_generator.uniqid"
                  class="Yokai\Batch\Factory\UniqidJobExecutionIdGenerator"/>
+
+        <service id="yokai_batch.job_execution_parameters_builder.chain"
+                 class="Yokai\Batch\Factory\JobExecutionParametersBuilder\ChainJobExecutionParametersBuilder">
+            <argument type="tagged_iterator" tag="yokai_batch.job_execution_parameters_builder"/>
+        </service>
     </services>
 </container>

--- a/src/batch-symfony-framework/tests/DependencyInjection/YokaiBatchExtensionTest.php
+++ b/src/batch-symfony-framework/tests/DependencyInjection/YokaiBatchExtensionTest.php
@@ -7,6 +7,7 @@ namespace Yokai\Batch\Tests\Bridge\Symfony\Framework\DependencyInjection;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
@@ -17,6 +18,10 @@ use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Templating\ConfigurableTe
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Templating\SonataAdminTemplating;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Templating\TemplatingInterface;
 use Yokai\Batch\Bridge\Symfony\Messenger\DispatchMessageJobLauncher;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\ChainJobExecutionParametersBuilder;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\PerJobJobExecutionParametersBuilder;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\StaticJobExecutionParametersBuilder;
+use Yokai\Batch\Factory\JobExecutionParametersBuilderInterface;
 use Yokai\Batch\Launcher\JobLauncherInterface;
 use Yokai\Batch\Launcher\SimpleJobLauncher;
 use Yokai\Batch\Storage\JobExecutionStorageInterface;
@@ -386,5 +391,108 @@ class YokaiBatchExtensionTest extends TestCase
             null,
             new ServiceNotFoundException('app.unknown'),
         ];
+    }
+
+    /**
+     * @dataProvider parameters
+     */
+    public function testParameters(array $config, array|null $global, array|null $perJob): void
+    {
+        $container = $this->createContainer($config);
+
+        $globalService = $this->getDefinition($container, 'yokai_batch.job_execution_parameters_builder.global');
+        if ($global !== null) {
+            self::assertNotNull($globalService);
+            self::assertSame(StaticJobExecutionParametersBuilder::class, $globalService->getClass());
+            self::assertTrue($globalService->hasTag('yokai_batch.job_execution_parameters_builder'));
+            self::assertSame($global, $globalService->getArgument('$parameters'));
+        } else {
+            self::assertNull($globalService);
+        }
+        $perJobService = $this->getDefinition($container, 'yokai_batch.job_execution_parameters_builder.per_job');
+        if ($perJob !== null) {
+            self::assertNotNull($perJobService);
+            self::assertSame(PerJobJobExecutionParametersBuilder::class, $perJobService->getClass());
+            self::assertTrue($perJobService->hasTag('yokai_batch.job_execution_parameters_builder'));
+            self::assertSame($perJob, $perJobService->getArgument('$perJobParameters'));
+        } else {
+            self::assertNull($perJobService);
+        }
+        $defaultService = $this->getDefinition($container, JobExecutionParametersBuilderInterface::class);
+        self::assertNotNull($defaultService);
+        self::assertSame(ChainJobExecutionParametersBuilder::class, $defaultService->getClass());
+        $defaultServiceBuilders = $defaultService->getArgument(0);
+        self::assertTrue($defaultServiceBuilders instanceof TaggedIteratorArgument);
+        /** @var TaggedIteratorArgument $defaultServiceBuilders */
+        self::assertSame('yokai_batch.job_execution_parameters_builder', $defaultServiceBuilders->getTag());
+    }
+
+    public function parameters(): \Generator
+    {
+        yield 'Global parameters' => [
+            ['parameters' => ['global' => ['global' => true]]],
+            ['global' => true],
+            null,
+        ];
+        yield 'Per job parameters' => [
+            ['parameters' => ['per_job' => ['job.foo' => ['foo' => true], 'job.bar' => ['bar' => true]]]],
+            null,
+            ['job.foo' => ['foo' => true], 'job.bar' => ['bar' => true]],
+        ];
+        yield 'Global AND per job parameters' => [
+            ['parameters' => [
+                'global' => ['global' => true],
+                'per_job' => ['job.foo' => ['foo' => true], 'job.bar' => ['bar' => true]],
+            ]],
+            ['global' => true],
+            ['job.foo' => ['foo' => true], 'job.bar' => ['bar' => true]],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidParameters
+     */
+    public function testInvalidParameters(array $config, \Exception $error): void
+    {
+        $this->expectExceptionObject($error);
+        $this->createContainer($config);
+    }
+
+    public function invalidParameters(): \Generator
+    {
+        yield 'Per job parameters value must be an array' => [
+            ['parameters' => ['per_job' => ['job.foo' => 'string']]],
+            new InvalidConfigurationException('Invalid configuration for path "yokai_batch.parameters.per_job.job.foo": Should be an array<string, mixed>.'),
+        ];
+        yield 'Per job parameters value must be a string indexed array' => [
+            ['parameters' => ['per_job' => ['job.foo' => [1, 2, 3]]]],
+            new InvalidConfigurationException('Invalid configuration for path "yokai_batch.parameters.per_job.job.foo": Should be an array<string, mixed>.'),
+        ];
+    }
+
+    private function createContainer(array $config, \Closure|null $configure = null): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        if ($configure !== null) {
+            $configure($container);
+        }
+        $container->registerExtension(new YokaiBatchExtension());
+        $container->loadFromExtension('yokai_batch', $config);
+
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
+        $container->getCompilerPassConfig()->setAfterRemovingPasses([]);
+        $container->compile();
+
+        return $container;
+    }
+
+    private function getDefinition(ContainerBuilder $container, string $id): Definition|null
+    {
+        try {
+            return $container->findDefinition($id);
+        } catch (ServiceNotFoundException) {
+            return null;
+        }
     }
 }

--- a/src/batch-symfony-framework/tests/DependencyInjection/YokaiBatchExtensionTest.php
+++ b/src/batch-symfony-framework/tests/DependencyInjection/YokaiBatchExtensionTest.php
@@ -462,11 +462,15 @@ class YokaiBatchExtensionTest extends TestCase
     {
         yield 'Per job parameters value must be an array' => [
             ['parameters' => ['per_job' => ['job.foo' => 'string']]],
-            new InvalidConfigurationException('Invalid configuration for path "yokai_batch.parameters.per_job.job.foo": Should be an array<string, mixed>.'),
+            new InvalidConfigurationException(
+                'Invalid configuration for path "yokai_batch.parameters.per_job.job.foo": Should be an array<string, mixed>.'
+            ),
         ];
         yield 'Per job parameters value must be a string indexed array' => [
             ['parameters' => ['per_job' => ['job.foo' => [1, 2, 3]]]],
-            new InvalidConfigurationException('Invalid configuration for path "yokai_batch.parameters.per_job.job.foo": Should be an array<string, mixed>.'),
+            new InvalidConfigurationException(
+                'Invalid configuration for path "yokai_batch.parameters.per_job.job.foo": Should be an array<string, mixed>.'
+            ),
         ];
     }
 

--- a/src/batch-symfony-messenger/tests/DispatchMessageJobLauncherTest.php
+++ b/src/batch-symfony-messenger/tests/DispatchMessageJobLauncherTest.php
@@ -10,6 +10,7 @@ use Yokai\Batch\BatchStatus;
 use Yokai\Batch\Bridge\Symfony\Messenger\DispatchMessageJobLauncher;
 use Yokai\Batch\Bridge\Symfony\Messenger\LaunchJobMessage;
 use Yokai\Batch\Factory\JobExecutionFactory;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\NullJobExecutionParametersBuilder;
 use Yokai\Batch\Factory\UniqidJobExecutionIdGenerator;
 use Yokai\Batch\Test\Factory\SequenceJobExecutionIdGenerator;
 use Yokai\Batch\Test\Storage\InMemoryJobExecutionStorage;
@@ -21,7 +22,7 @@ final class DispatchMessageJobLauncherTest extends TestCase
     public function testLaunch(): void
     {
         $jobLauncher = new DispatchMessageJobLauncher(
-            new JobExecutionFactory(new UniqidJobExecutionIdGenerator()),
+            new JobExecutionFactory(new UniqidJobExecutionIdGenerator(), new NullJobExecutionParametersBuilder()),
             $storage = new InMemoryJobExecutionStorage(),
             $messageBus = new BufferingMessageBus()
         );
@@ -41,9 +42,12 @@ final class DispatchMessageJobLauncherTest extends TestCase
     public function testLaunchWithNoId(): void
     {
         $jobLauncher = new DispatchMessageJobLauncher(
-            new JobExecutionFactory(new SequenceJobExecutionIdGenerator(['123456789'])),
+            new JobExecutionFactory(
+                new SequenceJobExecutionIdGenerator(['123456789']),
+                new NullJobExecutionParametersBuilder(),
+            ),
             $storage = new InMemoryJobExecutionStorage(),
-            $messageBus = new BufferingMessageBus()
+            $messageBus = new BufferingMessageBus(),
         );
 
         $jobExecutionFromLauncher = $jobLauncher->launch('testing');
@@ -60,7 +64,7 @@ final class DispatchMessageJobLauncherTest extends TestCase
     public function testLaunchAndMessengerFail(): void
     {
         $jobLauncher = new DispatchMessageJobLauncher(
-            new JobExecutionFactory(new UniqidJobExecutionIdGenerator()),
+            new JobExecutionFactory(new UniqidJobExecutionIdGenerator(), new NullJobExecutionParametersBuilder()),
             $storage = new InMemoryJobExecutionStorage(),
             new FailingMessageBus(new TransportException('This is a test'))
         );

--- a/src/batch-symfony-messenger/tests/LaunchJobMessageHandlerTest.php
+++ b/src/batch-symfony-messenger/tests/LaunchJobMessageHandlerTest.php
@@ -9,6 +9,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Yokai\Batch\Bridge\Symfony\Messenger\LaunchJobMessage;
 use Yokai\Batch\Bridge\Symfony\Messenger\LaunchJobMessageHandler;
 use Yokai\Batch\Factory\JobExecutionFactory;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\NullJobExecutionParametersBuilder;
 use Yokai\Batch\Job\JobExecutionAccessor;
 use Yokai\Batch\Job\JobExecutor;
 use Yokai\Batch\Job\JobInterface;
@@ -35,7 +36,10 @@ final class LaunchJobMessageHandlerTest extends TestCase
         $jobExecutionStorage = new InMemoryJobExecutionStorage();
         $handler = new LaunchJobMessageHandler(
             new JobExecutionAccessor(
-                new JobExecutionFactory(new SequenceJobExecutionIdGenerator(['123456'])),
+                new JobExecutionFactory(
+                    new SequenceJobExecutionIdGenerator(['123456']),
+                    new NullJobExecutionParametersBuilder(),
+                ),
                 $jobExecutionStorage,
             ),
             new JobExecutor(

--- a/src/batch/src/Factory/JobExecutionFactory.php
+++ b/src/batch/src/Factory/JobExecutionFactory.php
@@ -14,6 +14,7 @@ final class JobExecutionFactory
 {
     public function __construct(
         private JobExecutionIdGeneratorInterface $idGenerator,
+        private JobExecutionParametersBuilderInterface $parametersBuilder,
     ) {
     }
 
@@ -24,6 +25,7 @@ final class JobExecutionFactory
      */
     public function create(string $name, array $configuration = []): JobExecution
     {
+        $configuration = $configuration + $this->parametersBuilder->build($name);
         /** @var string $id */
         $id = $configuration['_id'] ??= $this->idGenerator->generate();
 

--- a/src/batch/src/Factory/JobExecutionParametersBuilder/ChainJobExecutionParametersBuilder.php
+++ b/src/batch/src/Factory/JobExecutionParametersBuilder/ChainJobExecutionParametersBuilder.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Factory\JobExecutionParametersBuilder;
+
+use Yokai\Batch\Factory\JobExecutionParametersBuilderInterface;
+
+/**
+ * This {@see JobExecutionParametersBuilderInterface} is using multiple {@see JobExecutionParametersBuilderInterface}
+ * implementations, calls each and merge the results into a single array.
+ * The later the {@see JobExecutionParametersBuilderInterface} is in the list, the more chance it's values will be kept.
+ */
+final class ChainJobExecutionParametersBuilder implements JobExecutionParametersBuilderInterface
+{
+    public function __construct(
+        /**
+         * @var iterable<JobExecutionParametersBuilderInterface>
+         */
+        private readonly iterable $builders,
+    ) {
+    }
+
+    public function build(string $name): array
+    {
+        $values = [];
+        foreach ($this->builders as $builder) {
+            $values[] = $builder->build($name);
+        }
+
+        if ($values === []) {
+            return [];
+        }
+
+        return \array_merge(...$values);
+    }
+}

--- a/src/batch/src/Factory/JobExecutionParametersBuilder/NullJobExecutionParametersBuilder.php
+++ b/src/batch/src/Factory/JobExecutionParametersBuilder/NullJobExecutionParametersBuilder.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Factory\JobExecutionParametersBuilder;
+
+use Yokai\Batch\Factory\JobExecutionParametersBuilderInterface;
+
+/**
+ * This {@see JobExecutionParametersBuilderInterface} has no default values to add.
+ */
+final class NullJobExecutionParametersBuilder implements JobExecutionParametersBuilderInterface
+{
+    public function build(string $name): array
+    {
+        return [];
+    }
+}

--- a/src/batch/src/Factory/JobExecutionParametersBuilder/PerJobJobExecutionParametersBuilder.php
+++ b/src/batch/src/Factory/JobExecutionParametersBuilder/PerJobJobExecutionParametersBuilder.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Factory\JobExecutionParametersBuilder;
+
+use Yokai\Batch\Factory\JobExecutionParametersBuilderInterface;
+
+/**
+ * This {@see JobExecutionParametersBuilderInterface} has different default values per job provided at construction.
+ */
+final class PerJobJobExecutionParametersBuilder implements JobExecutionParametersBuilderInterface
+{
+    public function __construct(
+        /**
+         * @var array<string, array<string, mixed>>
+         */
+        private readonly array $perJobParameters,
+    ) {
+    }
+
+    public function build(string $name): array
+    {
+        return $this->perJobParameters[$name] ?? [];
+    }
+}

--- a/src/batch/src/Factory/JobExecutionParametersBuilder/StaticJobExecutionParametersBuilder.php
+++ b/src/batch/src/Factory/JobExecutionParametersBuilder/StaticJobExecutionParametersBuilder.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Factory\JobExecutionParametersBuilder;
+
+use Yokai\Batch\Factory\JobExecutionParametersBuilderInterface;
+
+/**
+ * This {@see JobExecutionParametersBuilderInterface} has same default values for all jobs provided at construction.
+ */
+final class StaticJobExecutionParametersBuilder implements JobExecutionParametersBuilderInterface
+{
+    public function __construct(
+        /**
+         * @var array<string, mixed>
+         */
+        private readonly array $parameters,
+    ) {
+    }
+
+    public function build(string $name): array
+    {
+        return $this->parameters;
+    }
+}

--- a/src/batch/src/Factory/JobExecutionParametersBuilderInterface.php
+++ b/src/batch/src/Factory/JobExecutionParametersBuilderInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Factory;
+
+use Yokai\Batch\JobExecution;
+use Yokai\Batch\JobParameters;
+
+/**
+ * Used by {@see JobExecutionFactory} to build default {@see JobExecution} parameters hash.
+ */
+interface JobExecutionParametersBuilderInterface
+{
+    /**
+     * Returns an array hash to be given to {@see JobParameters}.
+     *
+     * @return array<string, mixed>
+     */
+    public function build(string $name): array;
+}

--- a/src/batch/tests/Factory/JobExecutionFactoryTest.php
+++ b/src/batch/tests/Factory/JobExecutionFactoryTest.php
@@ -6,6 +6,7 @@ namespace Yokai\Batch\Tests\Factory;
 
 use PHPUnit\Framework\TestCase;
 use Yokai\Batch\Factory\JobExecutionFactory;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\NullJobExecutionParametersBuilder;
 use Yokai\Batch\Factory\UniqidJobExecutionIdGenerator;
 use Yokai\Batch\JobExecution;
 
@@ -13,7 +14,10 @@ class JobExecutionFactoryTest extends TestCase
 {
     public function testCreate(): void
     {
-        $executionFactory = new JobExecutionFactory(new UniqidJobExecutionIdGenerator());
+        $executionFactory = new JobExecutionFactory(
+            new UniqidJobExecutionIdGenerator(),
+            new NullJobExecutionParametersBuilder()
+        );
 
         $executionWithoutConfig = $executionFactory->create('export');
         self::assertSame('export', $executionWithoutConfig->getJobName());

--- a/src/batch/tests/Factory/JobExecutionParametersBuilder/ChainJobExecutionParametersBuilderTest.php
+++ b/src/batch/tests/Factory/JobExecutionParametersBuilder/ChainJobExecutionParametersBuilderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Tests\Factory\JobExecutionParametersBuilder;
+
+use PHPUnit\Framework\TestCase;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\ChainJobExecutionParametersBuilder;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\PerJobJobExecutionParametersBuilder;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\StaticJobExecutionParametersBuilder;
+
+class ChainJobExecutionParametersBuilderTest extends TestCase
+{
+    public function test(): void
+    {
+        $builder = new ChainJobExecutionParametersBuilder([
+            new PerJobJobExecutionParametersBuilder([
+                'job.foo' => ['foo' => true],
+                'job.bar' => ['bar' => true],
+            ]),
+            new StaticJobExecutionParametersBuilder(['default' => true]),
+        ]);
+        self::assertSame(
+            ['foo' => true, 'default' => true],
+            $builder->build('job.foo'),
+        );
+        self::assertSame(
+            ['bar' => true, 'default' => true],
+            $builder->build('job.bar'),
+        );
+        self::assertSame(
+            ['default' => true],
+            $builder->build('job.baz'),
+        );
+    }
+}

--- a/src/batch/tests/Factory/JobExecutionParametersBuilder/NullJobExecutionParametersBuilderTest.php
+++ b/src/batch/tests/Factory/JobExecutionParametersBuilder/NullJobExecutionParametersBuilderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Tests\Factory\JobExecutionParametersBuilder;
+
+use PHPUnit\Framework\TestCase;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\NullJobExecutionParametersBuilder;
+
+class NullJobExecutionParametersBuilderTest extends TestCase
+{
+    public function test(): void
+    {
+        $builder = new NullJobExecutionParametersBuilder();
+        self::assertSame(
+            [],
+            $builder->build('job.foo'),
+        );
+        self::assertSame(
+            [],
+            $builder->build('job.baz'),
+        );
+    }
+}

--- a/src/batch/tests/Factory/JobExecutionParametersBuilder/PerJobJobExecutionParametersBuilderTest.php
+++ b/src/batch/tests/Factory/JobExecutionParametersBuilder/PerJobJobExecutionParametersBuilderTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Tests\Factory\JobExecutionParametersBuilder;
+
+use PHPUnit\Framework\TestCase;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\PerJobJobExecutionParametersBuilder;
+
+class PerJobJobExecutionParametersBuilderTest extends TestCase
+{
+    public function test(): void
+    {
+        $builder = new PerJobJobExecutionParametersBuilder([
+            'job.foo' => ['string' => 'foo', 'number' => 1, 'bool' => false],
+            'job.bar' => ['string' => 'bar', 'number' => 2, 'bool' => true],
+        ]);
+        self::assertSame(
+            ['string' => 'foo', 'number' => 1, 'bool' => false],
+            $builder->build('job.foo'),
+        );
+        self::assertSame(
+            ['string' => 'bar', 'number' => 2, 'bool' => true],
+            $builder->build('job.bar'),
+        );
+        self::assertSame(
+            [],
+            $builder->build('job.baz'),
+        );
+    }
+}

--- a/src/batch/tests/Factory/JobExecutionParametersBuilder/StaticJobExecutionParametersBuilderTest.php
+++ b/src/batch/tests/Factory/JobExecutionParametersBuilder/StaticJobExecutionParametersBuilderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Tests\Factory\JobExecutionParametersBuilder;
+
+use PHPUnit\Framework\TestCase;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\StaticJobExecutionParametersBuilder;
+
+class StaticJobExecutionParametersBuilderTest extends TestCase
+{
+    public function test(): void
+    {
+        $builder = new StaticJobExecutionParametersBuilder(['string' => 'foo', 'number' => 1, 'bool' => false]);
+        self::assertSame(
+            ['string' => 'foo', 'number' => 1, 'bool' => false],
+            $builder->build('job.foo'),
+        );
+        self::assertSame(
+            ['string' => 'foo', 'number' => 1, 'bool' => false],
+            $builder->build('job.baz'),
+        );
+    }
+}

--- a/src/batch/tests/Job/JobExecutionAccessorTest.php
+++ b/src/batch/tests/Job/JobExecutionAccessorTest.php
@@ -6,6 +6,7 @@ namespace Yokai\Batch\Tests\Job;
 
 use PHPUnit\Framework\TestCase;
 use Yokai\Batch\Factory\JobExecutionFactory;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\NullJobExecutionParametersBuilder;
 use Yokai\Batch\Job\JobExecutionAccessor;
 use Yokai\Batch\JobExecution;
 use Yokai\Batch\Test\Factory\SequenceJobExecutionIdGenerator;
@@ -16,10 +17,13 @@ class JobExecutionAccessorTest extends TestCase
     public function test(): void
     {
         $accessor = new JobExecutionAccessor(
-            new JobExecutionFactory(new SequenceJobExecutionIdGenerator(['123', '456'])),
+            new JobExecutionFactory(
+                new SequenceJobExecutionIdGenerator(['123', '456']),
+                new NullJobExecutionParametersBuilder(),
+            ),
             $storage = new InMemoryJobExecutionStorage(
-                $existing = JobExecution::createRoot('abc', 'test')
-            )
+                $existing = JobExecution::createRoot('abc', 'test'),
+            ),
         );
 
         self::assertSame($existing, $accessor->get('test', ['_id' => 'abc']));

--- a/src/batch/tests/Launcher/SimpleJobLauncherTest.php
+++ b/src/batch/tests/Launcher/SimpleJobLauncherTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Yokai\Batch\BatchStatus;
 use Yokai\Batch\Factory\JobExecutionFactory;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\NullJobExecutionParametersBuilder;
 use Yokai\Batch\Job\JobExecutionAccessor;
 use Yokai\Batch\Job\JobExecutor;
 use Yokai\Batch\Job\JobInterface;
@@ -26,14 +27,17 @@ class SimpleJobLauncherTest extends TestCase
 
         $launcher = new SimpleJobLauncher(
             new JobExecutionAccessor(
-                new JobExecutionFactory(new SequenceJobExecutionIdGenerator(['123'])),
+                new JobExecutionFactory(
+                    new SequenceJobExecutionIdGenerator(['123']),
+                    new NullJobExecutionParametersBuilder(),
+                ),
                 $jobExecutionStorage = new InMemoryJobExecutionStorage(),
             ),
             new JobExecutor(
                 JobRegistry::fromJobArray(['phpunit' => $job->reveal()]),
                 $jobExecutionStorage,
-                null
-            )
+                null,
+            ),
         );
 
         $execution = $launcher->launch('phpunit');

--- a/tests/integration/JobTestCase.php
+++ b/tests/integration/JobTestCase.php
@@ -7,6 +7,7 @@ namespace Yokai\Batch\Sources\Tests\Integration;
 use PHPUnit\Framework\TestCase;
 use Yokai\Batch\BatchStatus;
 use Yokai\Batch\Factory\JobExecutionFactory;
+use Yokai\Batch\Factory\JobExecutionParametersBuilder\NullJobExecutionParametersBuilder;
 use Yokai\Batch\Factory\UniqidJobExecutionIdGenerator;
 use Yokai\Batch\Failure;
 use Yokai\Batch\Job\JobExecutionAccessor;
@@ -51,7 +52,7 @@ abstract class JobTestCase extends TestCase
 
         $launcher = new SimpleJobLauncher(
             new JobExecutionAccessor(
-                new JobExecutionFactory(new UniqidJobExecutionIdGenerator()),
+                new JobExecutionFactory(new UniqidJobExecutionIdGenerator(), new NullJobExecutionParametersBuilder()),
                 $jobExecutionStorage
             ),
             self::createJobExecutor($jobExecutionStorage, [$jobName => $job])


### PR DESCRIPTION
See #93 

`\Yokai\Batch\Factory\JobExecutionParametersBuilderInterface` was introduced to provide some parameters defaults, to be merged with those provided at runtime

It is used in `\Yokai\Batch\Factory\JobExecutionFactory` before constructing `\Yokai\Batch\JobExecution`