### PR TITLE
Add missing "page-link" class on Bootstrap 4 pagination links

### DIFF
--- a/src/batch-symfony-framework/src/Resources/views/bootstrap4/list.html.twig
+++ b/src/batch-symfony-framework/src/Resources/views/bootstrap4/list.html.twig
@@ -116,6 +116,7 @@
             {% if pagination.current > 2 %}
                 <li class="page-item">
                     <a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): 1 }) }}"
+                       class="page-link"
                        title="{{ 'job.action.pagination_first'|trans }}">
                         <span aria-hidden="true">&laquo;</span>
                         <span class="sr-only">{{ 'job.action.pagination_first'|trans }}</span>
@@ -126,6 +127,7 @@
             {% if pagination.prev.enabled %}
                 <li class="page-item">
                     <a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): pagination.prev.value }) }}"
+                       class="page-link"
                        title="{{ 'job.action.pagination_prev'|trans }}">
                         <span aria-hidden="true">&lsaquo;</span>
                         <span class="sr-only">{{ 'job.action.pagination_prev'|trans }}</span>
@@ -136,6 +138,7 @@
             {% if pagination.next.enabled %}
                 <li class="page-item">
                     <a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): pagination.next.value }) }}"
+                       class="page-link"
                        title="{{ 'job.action.pagination_next'|trans }}">
                         <span aria-hidden="true">&rsaquo;</span>
                         <span class="sr-only">{{ 'job.action.pagination_next'|trans }}</span>


### PR DESCRIPTION
According to Bootstrap 4 documentation https://getbootstrap.com/docs/4.0/components/pagination/
All `<a>` tags in a `ul.pagination` must have the `page-link` class