### PR TITLE
Add missing "active" class on Sonata breadcrumbs last element

### DIFF
--- a/src/batch-symfony-framework/src/Resources/views/sonata/list.html.twig
+++ b/src/batch-symfony-framework/src/Resources/views/sonata/list.html.twig
@@ -26,7 +26,7 @@
                 <i class="fa fa-home"></i>
             </a>
         </li>
-        <li>
+        <li class="active">
             <span>
                 {{ 'job.name'|trans }}
             </span>

--- a/src/batch-symfony-framework/src/Resources/views/sonata/show.html.twig
+++ b/src/batch-symfony-framework/src/Resources/views/sonata/show.html.twig
@@ -60,7 +60,7 @@
         </li>
         {% set rootExecution = execution.rootExecution %}
         {% for parentPath, executionInPath in executionsPath %}
-            <li>
+            <li {% if loop.last %}class="active"{% endif %}>
                 {% if loop.last %}
                     <span>
                         {%- include '@YokaiBatch/sonata/show/_job-name-and-id.html.twig' with {execution: executionInPath} only -%}


### PR DESCRIPTION
Sonata admin is using AdminLTE, which is using Bootstrap (v3 for the moment)

And the breadcrumb last element requires an `active` CSS class
https://getbootstrap.com/docs/3.3/components/#breadcrumbs

```html
<ol class="breadcrumb">
  <li><a href="#">Home</a></li>
  <li><a href="#">Library</a></li>
  <li class="active">Data</li>
</ol>
```
