### PR TITLE
Fixed JobExecutionLogger PHPStan error

### DIFF
--- a/src/batch/src/JobExecutionLogger.php
+++ b/src/batch/src/JobExecutionLogger.php
@@ -40,7 +40,9 @@ final class JobExecutionLogger extends AbstractLogger
     }
 
     /**
+     * @param string               $level
      * @param array<string, mixed> $context
+     * @param string|\Stringable   $message
      */
     public function log($level, $message, array $context = []): void
     {


### PR DESCRIPTION
https://github.com/yokai-php/batch-src/actions/runs/10573936654/job/29294410218?pr=131

```
 ------ --------------------------------------------------------------------- 
  Line   batch/src/JobExecutionLogger.php                                     
 ------ --------------------------------------------------------------------- 
  45     Method Yokai\Batch\JobExecutionLogger::log() has parameter $message  
         with no type specified.                                              
 ------ --------------------------------------------------------------------- 

```