### PR TITLE
Get rid of unecessary phpstan prefix in some annotations

### DIFF
--- a/src/batch-doctrine-dbal/src/DoctrineDBALJobExecutionStorage.php
+++ b/src/batch-doctrine-dbal/src/DoctrineDBALJobExecutionStorage.php
@@ -41,7 +41,7 @@ final class DoctrineDBALJobExecutionStorage implements
     private JobExecutionRowNormalizer $normalizer;
 
     /**
-     * @phpstan-param array{connection?: string, table?: string} $options
+     * @param array{connection?: string, table?: string} $options
      */
     public function __construct(ConnectionRegistry $doctrine, array $options)
     {
@@ -153,8 +153,8 @@ final class DoctrineDBALJobExecutionStorage implements
             ->from($this->table);
 
         /**
-         * @phpstan-var array<string, mixed> $queryParameters
-         * @phpstan-var array<string, string|int> $queryTypes
+         * @var array<string, mixed> $queryParameters
+         * @var array<string, string|int> $queryTypes
          */
         [$queryParameters, $queryTypes] = $this->addWheres($query, $qb);
 
@@ -186,8 +186,8 @@ final class DoctrineDBALJobExecutionStorage implements
             ->from($this->table);
 
         /**
-         * @phpstan-var array<string, mixed> $queryParameters
-         * @phpstan-var array<string, string|int> $queryTypes
+         * @var array<string, mixed> $queryParameters
+         * @var array<string, string|int> $queryTypes
          */
         [$queryParameters, $queryTypes] = $this->addWheres($query, $qb);
 
@@ -226,7 +226,7 @@ final class DoctrineDBALJobExecutionStorage implements
     }
 
     /**
-     * @phpstan-return array<string, string>
+     * @return array<string, string>
      */
     private function types(): array
     {
@@ -246,7 +246,7 @@ final class DoctrineDBALJobExecutionStorage implements
     }
 
     /**
-     * @phpstan-return array<string, string>
+     * @return array<string, string>
      */
     private function identity(JobExecution $execution): array
     {
@@ -257,7 +257,7 @@ final class DoctrineDBALJobExecutionStorage implements
     }
 
     /**
-     * @phpstan-return array<string, string>
+     * @return array<string, string>
      * @throws DBALException
      */
     private function fetchRow(string $jobName, string $id): array
@@ -287,10 +287,10 @@ final class DoctrineDBALJobExecutionStorage implements
     }
 
     /**
-     * @phpstan-param array<string, mixed>      $parameters
-     * @phpstan-param array<string, int|string> $types
+     * @param array<string, mixed>      $parameters
+     * @param array<string, int|string> $types
      *
-     * @phpstan-return Generator<JobExecution>
+     * @return Generator<JobExecution>
      */
     private function queryList(string $query, array $parameters, array $types): Generator
     {
@@ -305,7 +305,7 @@ final class DoctrineDBALJobExecutionStorage implements
     }
 
     /**
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     private function toRow(JobExecution $jobExecution): array
     {
@@ -313,7 +313,7 @@ final class DoctrineDBALJobExecutionStorage implements
     }
 
     /**
-     * @phpstan-param array<string, mixed> $row
+     * @param array<string, mixed> $row
      */
     private function fromRow(array $row): JobExecution
     {

--- a/src/batch-doctrine-dbal/src/DoctrineDBALQueryCursorReader.php
+++ b/src/batch-doctrine-dbal/src/DoctrineDBALQueryCursorReader.php
@@ -55,7 +55,7 @@ final class DoctrineDBALQueryCursorReader implements ItemReaderInterface
     }
 
     /**
-     * @phpstan-return Generator<array<string, string>>
+     * @return Generator<array<string, string>>
      */
     public function read(): Generator
     {

--- a/src/batch-doctrine-dbal/src/DoctrineDBALQueryOffsetReader.php
+++ b/src/batch-doctrine-dbal/src/DoctrineDBALQueryOffsetReader.php
@@ -43,7 +43,7 @@ final class DoctrineDBALQueryOffsetReader implements ItemReaderInterface
     }
 
     /**
-     * @phpstan-return Generator<array<string, string>>
+     * @return Generator<array<string, string>>
      */
     public function read(): Generator
     {

--- a/src/batch-doctrine-dbal/src/DoctrineDBALUpsert.php
+++ b/src/batch-doctrine-dbal/src/DoctrineDBALUpsert.php
@@ -13,11 +13,11 @@ final class DoctrineDBALUpsert
     public function __construct(
         private string $table,
         /**
-         * @phpstan-var array<string, mixed>
+         * @var array<string, mixed>
          */
         private array $data,
         /**
-         * @phpstan-var array<string, mixed>
+         * @var array<string, mixed>
          */
         private array $identity = [],
     ) {
@@ -29,7 +29,7 @@ final class DoctrineDBALUpsert
     }
 
     /**
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     public function getData(): array
     {
@@ -37,7 +37,7 @@ final class DoctrineDBALUpsert
     }
 
     /**
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     public function getIdentity(): array
     {

--- a/src/batch-doctrine-dbal/src/JobExecutionRowNormalizer.php
+++ b/src/batch-doctrine-dbal/src/JobExecutionRowNormalizer.php
@@ -29,7 +29,7 @@ final class JobExecutionRowNormalizer
     /**
      * Convert a {@see JobExecution} object to a row data array.
      *
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     public function toRow(JobExecution $jobExecution): array
     {
@@ -51,7 +51,7 @@ final class JobExecutionRowNormalizer
     /**
      * Convert a row data array to a {@see JobExecution} object.
      *
-     * @phpstan-param array<string, mixed> $data
+     * @param array<string, mixed> $data
      */
     public function fromRow(array $data, JobExecution $parent = null): JobExecution
     {
@@ -99,7 +99,7 @@ final class JobExecutionRowNormalizer
     }
 
     /**
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     private function toChildRow(JobExecution $jobExecution): array
     {
@@ -117,9 +117,9 @@ final class JobExecutionRowNormalizer
     }
 
     /**
-     * @phpstan-param array<int|string, mixed>|string $value
+     * @param array<int|string, mixed>|string $value
      *
-     * @phpstan-return array<int|string, mixed>
+     * @return array<int|string, mixed>
      */
     private function jsonFromString(array|string $value): array
     {
@@ -144,7 +144,7 @@ final class JobExecutionRowNormalizer
     }
 
     /**
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     private function failureToArray(Failure $failure): array
     {
@@ -158,7 +158,7 @@ final class JobExecutionRowNormalizer
     }
 
     /**
-     * @phpstan-param array<string, mixed> $array
+     * @param array<string, mixed> $array
      */
     private function failureFromArray(array $array): Failure
     {
@@ -172,7 +172,7 @@ final class JobExecutionRowNormalizer
     }
 
     /**
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     private function warningToArray(Warning $warning): array
     {
@@ -184,7 +184,7 @@ final class JobExecutionRowNormalizer
     }
 
     /**
-     * @phpstan-param array<string, mixed> $array
+     * @param array<string, mixed> $array
      */
     private function warningFromArray(array $array): Warning
     {

--- a/src/batch-symfony-console/src/CommandRunner.php
+++ b/src/batch-symfony-console/src/CommandRunner.php
@@ -30,7 +30,7 @@ class CommandRunner
     /**
      * Run a command asynchronously.
      *
-     * @phpstan-param array<string, mixed> $arguments
+     * @param array<string, mixed> $arguments
      */
     public function runAsync(string $commandName, string $logFilename, array $arguments = []): void
     {
@@ -52,7 +52,7 @@ class CommandRunner
     }
 
     /**
-     * @phpstan-param array<string, mixed> $arguments
+     * @param array<string, mixed> $arguments
      */
     private function buildCommand(string $commandName, array $arguments): string
     {

--- a/src/batch-symfony-console/src/RunJobCommand.php
+++ b/src/batch-symfony-console/src/RunJobCommand.php
@@ -108,7 +108,7 @@ final class RunJobCommand extends Command
     /**
      * @throws InvalidArgumentException
      *
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     private function decodeConfiguration(string $data): array
     {

--- a/src/batch-symfony-framework/src/DependencyInjection/CompilerPass/RegisterJobsCompilerPass.php
+++ b/src/batch-symfony-framework/src/DependencyInjection/CompilerPass/RegisterJobsCompilerPass.php
@@ -38,7 +38,7 @@ final class RegisterJobsCompilerPass implements CompilerPassInterface
     }
 
     /**
-     * @phpstan-param array<string, mixed> $attributes
+     * @param array<string, mixed> $attributes
      */
     private function getJobName(string $id, Definition $definition, array $attributes): string
     {

--- a/src/batch-symfony-framework/src/DependencyInjection/YokaiBatchExtension.php
+++ b/src/batch-symfony-framework/src/DependencyInjection/YokaiBatchExtension.php
@@ -42,7 +42,7 @@ use Yokai\Batch\Storage\QueryableJobExecutionStorageInterface;
 final class YokaiBatchExtension extends Extension
 {
     /**
-     * @phpstan-param list<array<string, mixed>> $configs
+     * @param list<array<string, mixed>> $configs
      */
     public function load(array $configs, ContainerBuilder $container): void
     {

--- a/src/batch-symfony-messenger/src/LaunchJobMessage.php
+++ b/src/batch-symfony-messenger/src/LaunchJobMessage.php
@@ -12,7 +12,7 @@ final class LaunchJobMessage
     public function __construct(
         private string $jobName,
         /**
-         * @phpstan-var array<string, mixed>
+         * @var array<string, mixed>
          */
         private array $configuration = [],
     ) {
@@ -24,7 +24,7 @@ final class LaunchJobMessage
     }
 
     /**
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     public function getConfiguration(): array
     {

--- a/src/batch-symfony-serializer/src/DenormalizeItemProcessor.php
+++ b/src/batch-symfony-serializer/src/DenormalizeItemProcessor.php
@@ -20,7 +20,7 @@ final class DenormalizeItemProcessor implements ItemProcessorInterface
         private string $type,
         private ?string $format = null,
         /**
-         * @phpstan-var array<string, mixed>
+         * @var array<string, mixed>
          */
         private array $context = [],
     ) {

--- a/src/batch-symfony-serializer/src/NormalizeItemProcessor.php
+++ b/src/batch-symfony-serializer/src/NormalizeItemProcessor.php
@@ -19,7 +19,7 @@ final class NormalizeItemProcessor implements ItemProcessorInterface
         private NormalizerInterface $normalizer,
         private ?string $format = null,
         /**
-         * @phpstan-var array<string, mixed>
+         * @var array<string, mixed>
          */
         private array $context = [],
     ) {

--- a/src/batch-symfony-validator/src/SkipInvalidItemProcessor.php
+++ b/src/batch-symfony-validator/src/SkipInvalidItemProcessor.php
@@ -45,7 +45,7 @@ final class SkipInvalidItemProcessor implements ItemProcessorInterface
     /**
      * @param Constraint[]|null $constraints
      *
-     * @phpstan-return Iterator<string>
+     * @return Iterator<string>
      */
     private function normalizeConstraints(?array $constraints): Iterator
     {

--- a/src/batch-symfony-validator/src/SkipItemOnViolations.php
+++ b/src/batch-symfony-validator/src/SkipItemOnViolations.php
@@ -18,7 +18,7 @@ final class SkipItemOnViolations implements SkipItemCauseInterface
 {
     public function __construct(
         /**
-         * @phpstan-var ConstraintViolationListInterface<ConstraintViolationInterface>
+         * @var ConstraintViolationListInterface<ConstraintViolationInterface>
          */
         private ConstraintViolationListInterface $violations
     ) {
@@ -48,7 +48,7 @@ final class SkipItemOnViolations implements SkipItemCauseInterface
     }
 
     /**
-     * @phpstan-return ConstraintViolationListInterface<ConstraintViolationInterface>
+     * @return ConstraintViolationListInterface<ConstraintViolationInterface>
      */
     public function getViolations(): ConstraintViolationListInterface
     {

--- a/src/batch/src/Factory/JobExecutionFactory.php
+++ b/src/batch/src/Factory/JobExecutionFactory.php
@@ -21,7 +21,7 @@ final class JobExecutionFactory
     /**
      * Create a {@see JobExecution}.
      *
-     * @phpstan-param array<string, mixed> $configuration
+     * @param array<string, mixed> $configuration
      */
     public function create(string $name, array $configuration = []): JobExecution
     {

--- a/src/batch/src/Failure.php
+++ b/src/batch/src/Failure.php
@@ -27,7 +27,7 @@ final class Failure implements \Stringable
         private int $code,
         /**
          * Some extra parameters that a developer has provided
-         * @phpstan-var array<string, string>
+         * @var array<string, string>
          */
         private array $parameters = [],
         /**
@@ -40,7 +40,7 @@ final class Failure implements \Stringable
     /**
      * Static constructor from an exception.
      *
-     * @phpstan-param array<string, string> $parameters
+     * @param array<string, string> $parameters
      */
     public static function fromException(Throwable $exception, array $parameters = []): self
     {
@@ -74,7 +74,7 @@ final class Failure implements \Stringable
     }
 
     /**
-     * @phpstan-return array<string, string>
+     * @return array<string, string>
      */
     public function getParameters(): array
     {

--- a/src/batch/src/Finder/CallbackFinder.php
+++ b/src/batch/src/Finder/CallbackFinder.php
@@ -15,11 +15,11 @@ class CallbackFinder implements FinderInterface
 {
     public function __construct(
         /**
-         * @phpstan-var list<array{0: callable, 1: T}>
+         * @var list<array{0: callable, 1: T}>
          */
         private array $strategies,
         /**
-         * @phpstan-var T
+         * @var T
          */
         private object $default,
     ) {

--- a/src/batch/src/Finder/ClassMapFinder.php
+++ b/src/batch/src/Finder/ClassMapFinder.php
@@ -14,8 +14,8 @@ namespace Yokai\Batch\Finder;
 class ClassMapFinder extends CallbackFinder
 {
     /**
-     * @phpstan-param array<class-string, T> $classMap
-     * @phpstan-param T $default
+     * @param array<class-string, T> $classMap
+     * @param T $default
      */
     public function __construct(array $classMap, object $default)
     {

--- a/src/batch/src/Finder/FinderInterface.php
+++ b/src/batch/src/Finder/FinderInterface.php
@@ -8,7 +8,7 @@ namespace Yokai\Batch\Finder;
  * A finder is a component that is able to
  * filter out the appropriate subcomponent from a list.
  *
- * @phpstan-template T of object
+ * @template T of object
  */
 interface FinderInterface
 {
@@ -18,7 +18,7 @@ interface FinderInterface
      * @param mixed $subject The subject that should help to find component
      *
      * @return object The component that matches the subject
-     * @phpstan-return T
+     * @return T
      */
     public function find(mixed $subject): object;
 }

--- a/src/batch/src/Job/Item/AbstractElementDecorator.php
+++ b/src/batch/src/Job/Item/AbstractElementDecorator.php
@@ -48,7 +48,7 @@ abstract class AbstractElementDecorator implements
     /**
      * Implement this method and return all elements that your class is decorating.
      *
-     * @phpstan-return iterable<object>
+     * @return iterable<object>
      */
     abstract protected function getDecoratedElements(): iterable;
 }

--- a/src/batch/src/Job/Item/Exception/SkipItemException.php
+++ b/src/batch/src/Job/Item/Exception/SkipItemException.php
@@ -20,7 +20,7 @@ final class SkipItemException extends RuntimeException
         private mixed $item,
         private ?SkipItemCauseInterface $cause,
         /**
-         * @phpstan-var array<string, mixed>
+         * @var array<string, mixed>
          */
         private array $context = [],
     ) {
@@ -30,7 +30,7 @@ final class SkipItemException extends RuntimeException
     /**
      * Use this method when it's normal to skip this item.
      *
-     * @phpstan-param array<string, mixed> $context
+     * @param array<string, mixed> $context
      */
     public static function justSkip(mixed $item, array $context = []): self
     {
@@ -40,7 +40,7 @@ final class SkipItemException extends RuntimeException
     /**
      * Use this method when an error occurs, and you want to mark this item as errored.
      *
-     * @phpstan-param array<string, mixed> $context
+     * @param array<string, mixed> $context
      */
     public static function onError(mixed $item, Throwable $error, array $context = []): self
     {
@@ -50,7 +50,7 @@ final class SkipItemException extends RuntimeException
     /**
      * Use this method when something seems weird with an item, and you want to warn about it.
      *
-     * @phpstan-param array<string, mixed> $context
+     * @param array<string, mixed> $context
      */
     public static function withWarning(mixed $item, string $message, array $context = []): self
     {
@@ -76,7 +76,7 @@ final class SkipItemException extends RuntimeException
 
     /**
      * Some contextual information provided by the developer.
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     public function getContext(): array
     {

--- a/src/batch/src/Job/Item/ExpandProcessedItem.php
+++ b/src/batch/src/Job/Item/ExpandProcessedItem.php
@@ -18,12 +18,12 @@ use IteratorIterator;
 final class ExpandProcessedItem implements IteratorAggregate
 {
     /**
-     * @phpstan-var Iterator<mixed>
+     * @var Iterator<mixed>
      */
     private Iterator $iterator;
 
     /**
-     * @phpstan-param iterable<mixed> $iterator
+     * @param iterable<mixed> $iterator
      */
     public function __construct(iterable $iterator)
     {
@@ -35,7 +35,7 @@ final class ExpandProcessedItem implements IteratorAggregate
     }
 
     /**
-     * @phpstan-return Iterator<mixed>
+     * @return Iterator<mixed>
      */
     public function getIterator(): Iterator
     {

--- a/src/batch/src/Job/Item/ItemJob.php
+++ b/src/batch/src/Job/Item/ItemJob.php
@@ -26,7 +26,7 @@ class ItemJob implements JobInterface
     use ElementConfiguratorTrait;
 
     /**
-     * @phpstan-var list<object>
+     * @var list<object>
      */
     private array $elements;
 

--- a/src/batch/src/Job/Item/ItemReaderInterface.php
+++ b/src/batch/src/Job/Item/ItemReaderInterface.php
@@ -12,7 +12,7 @@ interface ItemReaderInterface
     /**
      * A list of items to process and write.
      *
-     * @phpstan-return iterable<mixed>
+     * @return iterable<mixed>
      */
     public function read(): iterable;
 }

--- a/src/batch/src/Job/Item/ItemWriterInterface.php
+++ b/src/batch/src/Job/Item/ItemWriterInterface.php
@@ -13,7 +13,7 @@ interface ItemWriterInterface
      * Writes items.
      *
      * @param iterable $items A batch of items to write
-     * @phpstan-param iterable<mixed> $items
+     * @param iterable<mixed> $items
      */
     public function write(iterable $items): void;
 }

--- a/src/batch/src/Job/Item/Processor/ArrayMapProcessor.php
+++ b/src/batch/src/Job/Item/Processor/ArrayMapProcessor.php
@@ -21,7 +21,7 @@ final class ArrayMapProcessor implements ItemProcessorInterface
     }
 
     /**
-     * @phpstan-return array<int|string, mixed>
+     * @return array<int|string, mixed>
      */
     public function process(mixed $item): array
     {

--- a/src/batch/src/Job/Item/Processor/FilterUniqueProcessor.php
+++ b/src/batch/src/Job/Item/Processor/FilterUniqueProcessor.php
@@ -20,7 +20,7 @@ final class FilterUniqueProcessor implements ItemProcessorInterface
     private Closure $extractUnique;
 
     /**
-     * @phpstan-var array<string, bool>
+     * @var array<string, bool>
      */
     private array $encountered = [];
 

--- a/src/batch/src/Job/Item/Processor/RoutingProcessor.php
+++ b/src/batch/src/Job/Item/Processor/RoutingProcessor.php
@@ -33,7 +33,7 @@ final class RoutingProcessor implements
 
     public function __construct(
         /**
-         * @phpstan-var FinderInterface<ItemProcessorInterface>
+         * @var FinderInterface<ItemProcessorInterface>
          */
         private FinderInterface $finder,
     ) {

--- a/src/batch/src/Job/Item/Reader/AddMetadataReader.php
+++ b/src/batch/src/Job/Item/Reader/AddMetadataReader.php
@@ -19,14 +19,14 @@ final class AddMetadataReader extends AbstractElementDecorator implements ItemRe
     public function __construct(
         private ItemReaderInterface $reader,
         /**
-         * @phpstan-var array<string, mixed>
+         * @var array<string, mixed>
          */
         private array $metadata,
     ) {
     }
 
     /**
-     * @phpstan-return Generator<array<mixed>>
+     * @return Generator<array<mixed>>
      */
     public function read(): Generator
     {

--- a/src/batch/src/Job/Item/Reader/Filesystem/FixedColumnSizeFileReader.php
+++ b/src/batch/src/Job/Item/Reader/Filesystem/FixedColumnSizeFileReader.php
@@ -46,7 +46,7 @@ final class FixedColumnSizeFileReader implements
     }
 
     /**
-     * @phpstan-return Generator<array<mixed>>
+     * @return Generator<array<mixed>>
      */
     public function read(): Generator
     {

--- a/src/batch/src/Job/Item/Reader/Filesystem/JsonLinesReader.php
+++ b/src/batch/src/Job/Item/Reader/Filesystem/JsonLinesReader.php
@@ -28,7 +28,7 @@ final class JsonLinesReader implements
     }
 
     /**
-     * @phpstan-return Generator<mixed>
+     * @return Generator<mixed>
      */
     public function read(): Generator
     {

--- a/src/batch/src/Job/Item/Reader/StaticIterableReader.php
+++ b/src/batch/src/Job/Item/Reader/StaticIterableReader.php
@@ -13,7 +13,7 @@ final class StaticIterableReader implements ItemReaderInterface
 {
     public function __construct(
         /**
-         * @phpstan-var iterable<mixed>
+         * @var iterable<mixed>
          */
         private iterable $items,
     ) {

--- a/src/batch/src/Job/Item/Writer/RoutingWriter.php
+++ b/src/batch/src/Job/Item/Writer/RoutingWriter.php
@@ -33,7 +33,7 @@ final class RoutingWriter implements
 
     public function __construct(
         /**
-         * @phpstan-var FinderInterface<ItemWriterInterface>
+         * @var FinderInterface<ItemWriterInterface>
          */
         private FinderInterface $finder,
     ) {

--- a/src/batch/src/Job/Parameters/ChainParameterAccessor.php
+++ b/src/batch/src/Job/Parameters/ChainParameterAccessor.php
@@ -15,7 +15,7 @@ final class ChainParameterAccessor implements JobParameterAccessorInterface
 {
     public function __construct(
         /**
-         * @phpstan-var iterable<JobParameterAccessorInterface>
+         * @var iterable<JobParameterAccessorInterface>
          */
         private iterable $accessors,
     ) {

--- a/src/batch/src/Job/Parameters/ReplaceWithVariablesParameterAccessor.php
+++ b/src/batch/src/Job/Parameters/ReplaceWithVariablesParameterAccessor.php
@@ -16,7 +16,7 @@ class ReplaceWithVariablesParameterAccessor implements JobParameterAccessorInter
     public function __construct(
         private JobParameterAccessorInterface $accessor,
         /**
-         * @phpstan-var array<string, string>
+         * @var array<string, string>
          */
         private array $variables = []
     ) {
@@ -33,7 +33,7 @@ class ReplaceWithVariablesParameterAccessor implements JobParameterAccessorInter
     }
 
     /**
-     * @phpstan-return array<string, string>
+     * @return array<string, string>
      */
     protected function getVariables(JobExecution $execution): array
     {

--- a/src/batch/src/JobExecution.php
+++ b/src/batch/src/JobExecution.php
@@ -305,7 +305,7 @@ final class JobExecution
     /**
      * Add a failure, build from exception, to the execution.
      *
-     * @phpstan-param array<string, string> $parameters
+     * @param array<string, string> $parameters
      */
     public function addFailureException(Throwable $exception, array $parameters = [], bool $log = true): void
     {

--- a/src/batch/src/JobParameters.php
+++ b/src/batch/src/JobParameters.php
@@ -23,7 +23,7 @@ final class JobParameters implements
 {
     public function __construct(
         /**
-         * @phpstan-var array<string, mixed>
+         * @var array<string, mixed>
          */
         private array $parameters = [],
     ) {
@@ -32,7 +32,7 @@ final class JobParameters implements
     /**
      * Get all parameter values.
      *
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     public function all(): array
     {
@@ -67,7 +67,7 @@ final class JobParameters implements
     }
 
     /**
-     * @phpstan-return ArrayIterator<string, mixed>
+     * @return ArrayIterator<string, mixed>
      */
     public function getIterator(): ArrayIterator
     {

--- a/src/batch/src/Launcher/JobLauncherInterface.php
+++ b/src/batch/src/Launcher/JobLauncherInterface.php
@@ -19,7 +19,7 @@ interface JobLauncherInterface
      *
      * @return JobExecution Information about job's execution
      *
-     * @phpstan-param array<string, mixed> $configuration
+     * @param array<string, mixed> $configuration
      */
     public function launch(string $name, array $configuration = []): JobExecution;
 }

--- a/src/batch/src/Serializer/JsonJobExecutionSerializer.php
+++ b/src/batch/src/Serializer/JsonJobExecutionSerializer.php
@@ -62,7 +62,7 @@ final class JsonJobExecutionSerializer implements JobExecutionSerializerInterfac
     }
 
     /**
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     private function toArray(JobExecution $jobExecution): array
     {
@@ -82,7 +82,7 @@ final class JsonJobExecutionSerializer implements JobExecutionSerializerInterfac
     }
 
     /**
-     * @phpstan-param array<string, mixed> $jobExecutionData
+     * @param array<string, mixed> $jobExecutionData
      */
     private function fromArray(array $jobExecutionData, JobExecution $parentExecution = null): JobExecution
     {
@@ -146,7 +146,7 @@ final class JsonJobExecutionSerializer implements JobExecutionSerializerInterfac
     }
 
     /**
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     private function failureToArray(Failure $failure): array
     {
@@ -160,7 +160,7 @@ final class JsonJobExecutionSerializer implements JobExecutionSerializerInterfac
     }
 
     /**
-     * @phpstan-param array<string, mixed> $array
+     * @param array<string, mixed> $array
      */
     private function failureFromArray(array $array): Failure
     {
@@ -174,7 +174,7 @@ final class JsonJobExecutionSerializer implements JobExecutionSerializerInterfac
     }
 
     /**
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     private function warningToArray(Warning $warning): array
     {
@@ -186,7 +186,7 @@ final class JsonJobExecutionSerializer implements JobExecutionSerializerInterfac
     }
 
     /**
-     * @phpstan-param array<string, mixed> $array
+     * @param array<string, mixed> $array
      */
     private function warningFromArray(array $array): Warning
     {

--- a/src/batch/src/Summary.php
+++ b/src/batch/src/Summary.php
@@ -25,7 +25,7 @@ final class Summary implements
 {
     public function __construct(
         /**
-         * @phpstan-var array<string, mixed>
+         * @var array<string, mixed>
          */
         private array $values = [],
     ) {
@@ -79,7 +79,7 @@ final class Summary implements
     /**
      * Get all values.
      *
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     public function all(): array
     {
@@ -95,7 +95,7 @@ final class Summary implements
     }
 
     /**
-     * @phpstan-return ArrayIterator<string, mixed>
+     * @return ArrayIterator<string, mixed>
      */
     public function getIterator(): ArrayIterator
     {

--- a/src/batch/src/Test/Factory/SequenceJobExecutionIdGenerator.php
+++ b/src/batch/src/Test/Factory/SequenceJobExecutionIdGenerator.php
@@ -13,13 +13,13 @@ use Yokai\Batch\Factory\JobExecutionIdGeneratorInterface;
 final class SequenceJobExecutionIdGenerator implements JobExecutionIdGeneratorInterface
 {
     /**
-     * @phpstan-var list<string>
+     * @var list<string>
      */
     private array $sequence;
     private int $current = 0;
 
     /**
-     * @phpstan-param list<string> $sequence
+     * @param list<string> $sequence
      */
     public function __construct(array $sequence)
     {

--- a/src/batch/src/Test/Finder/DummyFinder.php
+++ b/src/batch/src/Test/Finder/DummyFinder.php
@@ -16,7 +16,7 @@ final class DummyFinder implements FinderInterface
 {
     public function __construct(
         /**
-         * @phpstan-var T
+         * @var T
          */
         private object $object,
     ) {

--- a/src/batch/src/Test/Job/Item/Writer/InMemoryWriter.php
+++ b/src/batch/src/Test/Job/Item/Writer/InMemoryWriter.php
@@ -16,12 +16,12 @@ use Yokai\Batch\Job\Item\ItemWriterInterface;
 final class InMemoryWriter implements ItemWriterInterface, InitializableInterface
 {
     /**
-     * @phpstan-var list<mixed>
+     * @var list<mixed>
      */
     private array $items = [];
 
     /**
-     * @phpstan-var list<list<mixed>>
+     * @var list<list<mixed>>
      */
     private array $batchItems = [];
 
@@ -41,7 +41,7 @@ final class InMemoryWriter implements ItemWriterInterface, InitializableInterfac
     }
 
     /**
-     * @phpstan-return list<mixed>
+     * @return list<mixed>
      */
     public function getItems(): array
     {
@@ -49,7 +49,7 @@ final class InMemoryWriter implements ItemWriterInterface, InitializableInterfac
     }
 
     /**
-     * @phpstan-return list<list<mixed>>
+     * @return list<list<mixed>>
      */
     public function getBatchItems(): array
     {

--- a/src/batch/src/Trigger/Scheduler/CallbackScheduler.php
+++ b/src/batch/src/Trigger/Scheduler/CallbackScheduler.php
@@ -23,12 +23,12 @@ use Yokai\Batch\JobExecution;
 class CallbackScheduler implements SchedulerInterface
 {
     /**
-     * @phpstan-var list<array{0: callable, 1: string, 2: array<string, mixed>, 3: string|null}>
+     * @var list<array{0: callable, 1: string, 2: array<string, mixed>, 3: string|null}>
      */
     private array $config;
 
     /**
-     * @phpstan-param list<array{0: callable, 1: string, 2: array<string, mixed>|null, 3: string|null}> $config
+     * @param list<array{0: callable, 1: string, 2: array<string, mixed>|null, 3: string|null}> $config
      */
     public function __construct(array $config)
     {
@@ -44,7 +44,7 @@ class CallbackScheduler implements SchedulerInterface
     }
 
     /**
-     * @phpstan-return Generator<ScheduledJob>
+     * @return Generator<ScheduledJob>
      */
     public function get(JobExecution $execution): Generator
     {

--- a/src/batch/src/Trigger/Scheduler/ScheduledJob.php
+++ b/src/batch/src/Trigger/Scheduler/ScheduledJob.php
@@ -12,7 +12,7 @@ final class ScheduledJob
     public function __construct(
         private string $jobName,
         /**
-         * @phpstan-var array<string, mixed>
+         * @var array<string, mixed>
          */
         private array $parameters = [],
         private ?string $id = null,
@@ -30,7 +30,7 @@ final class ScheduledJob
     /**
      * The job parameters for the job to trigger.
      *
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     public function getParameters(): array
     {

--- a/src/batch/src/Trigger/Scheduler/SchedulerInterface.php
+++ b/src/batch/src/Trigger/Scheduler/SchedulerInterface.php
@@ -15,7 +15,7 @@ interface SchedulerInterface
      * Get list of job to schedule.
      *
      * @return ScheduledJob[]
-     * @phpstan-return iterable<ScheduledJob>
+     * @return iterable<ScheduledJob>
      */
     public function get(JobExecution $execution): iterable;
 }

--- a/src/batch/src/Trigger/Scheduler/TimeScheduler.php
+++ b/src/batch/src/Trigger/Scheduler/TimeScheduler.php
@@ -24,7 +24,7 @@ use Yokai\Batch\JobExecution;
 final class TimeScheduler extends CallbackScheduler
 {
     /**
-     * @phpstan-param list<array{0: DateTimeInterface, 1: string, 2: array<string, mixed>|null, 3: string|null}> $config
+     * @param list<array{0: DateTimeInterface, 1: string, 2: array<string, mixed>|null, 3: string|null}> $config
      */
     public function __construct(array $config)
     {

--- a/src/batch/src/Trigger/TriggerScheduledJobsJob.php
+++ b/src/batch/src/Trigger/TriggerScheduledJobsJob.php
@@ -18,7 +18,7 @@ use Yokai\Batch\Trigger\Scheduler\SchedulerInterface;
 final class TriggerScheduledJobsJob implements JobInterface
 {
     /**
-     * @phpstan-param iterable<SchedulerInterface> $schedulers
+     * @param iterable<SchedulerInterface> $schedulers
      */
     public function __construct(
         /**

--- a/src/batch/src/Warning.php
+++ b/src/batch/src/Warning.php
@@ -18,12 +18,12 @@ final class Warning implements \Stringable
         private string $message,
         /**
          * The warning message parameters.
-         * @phpstan-var array<string, string>
+         * @var array<string, string>
          */
         private array $parameters = [],
         /**
          * Some extra parameters that a developer has provided.
-         * @phpstan-var array<string, mixed>
+         * @var array<string, mixed>
          */
         private array $context = [],
     ) {
@@ -40,7 +40,7 @@ final class Warning implements \Stringable
     }
 
     /**
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     public function getParameters(): array
     {
@@ -48,7 +48,7 @@ final class Warning implements \Stringable
     }
 
     /**
-     * @phpstan-return array<string, mixed>
+     * @return array<string, mixed>
      */
     public function getContext(): array
     {


### PR DESCRIPTION
At some point of history, IDEs were late on some advanced typing notations
We used to write some instruction for phpstan only
Now IDE understand phpstan almost perfectly
We can remove the phpstan prefix from most annotations