### PR TITLE
Fixed wrong doc links in packages README files

### DIFF
--- a/docs/docs/bridges/symfony-serializer.rst
+++ b/docs/docs/bridges/symfony-serializer.rst
@@ -8,11 +8,6 @@ Denormalize item processor
 
 todo
 
-Job execution serializer
-------------------------------------------------------------
-
-todo
-
 Normalize item processor
 ------------------------------------------------------------
 

--- a/src/batch-doctrine-dbal/README.md
+++ b/src/batch-doctrine-dbal/README.md
@@ -22,9 +22,15 @@ composer require yokai/batch-doctrine-dbal
 
 ## Documentation
 
+Please read the [dedicated documentation page](https://yokai-batch.readthedocs.io/en/0.x/bridges/doctrine-dbal.html).
+
 This package provides:
 
-- a [job execution storage](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-doctrine-dbal/job-execution-storage.md) that stores job executions to a relational database
+- an [item job writer](https://github.com/yokai-php/batch-doctrine-dbal/blob/0.x/src/DoctrineDBALInsertWriter.php) that insert into an SQL table
+- a [job execution storage](https://github.com/yokai-php/batch-doctrine-dbal/blob/0.x/src/DoctrineDBALJobExecutionStorage.php) that stores job executions to a relational database
+- an [item job reader](https://github.com/yokai-php/batch-doctrine-dbal/blob/0.x/src/DoctrineDBALQueryCursorReader.php) that read from an SQL table using cursor pagination
+- an [item job reader](https://github.com/yokai-php/batch-doctrine-dbal/blob/0.x/src/DoctrineDBALQueryOffsetReader.php) that read from an SQL table using limit + offset pagination
+- an [item job writer](https://github.com/yokai-php/batch-doctrine-dbal/blob/0.x/src/DoctrineDBALUpsertWriter.php) that insert or update into an SQL table
 
 
 ## Contribution

--- a/src/batch-doctrine-orm/README.md
+++ b/src/batch-doctrine-orm/README.md
@@ -22,9 +22,11 @@ composer require yokai/batch-doctrine-orm
 
 ## Documentation
 
+Please read the [dedicated documentation page](https://yokai-batch.readthedocs.io/en/0.x/bridges/doctrine-orm.html).
+
 This package provides:
 
-- an [item reader](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-doctrine-orm/entity-item-reader.md) that read entities from entity manager
+- an [item job reader](https://github.com/yokai-php/batch-doctrine-orm/blob/0.x/src/EntityReader.php) that read all entities of a type
 
 
 ## Contribution

--- a/src/batch-doctrine-persistence/README.md
+++ b/src/batch-doctrine-persistence/README.md
@@ -22,10 +22,12 @@ composer require yokai/batch-doctrine-persistence
 
 ## Documentation
 
+Please read the [dedicated documentation page](https://yokai-batch.readthedocs.io/en/0.x/bridges/doctrine-persistence.html).
+
 This package provides:
 
-- an [item writer](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-doctrine-persistence/object-item-writer.md) that persists objects through object manager
-- an [object registry](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-doctrine-persistence/object-registry.md) that remembers found objects identities
+- an [object registry](https://github.com/yokai-php/batch-doctrine-persistence/blob/0.x/src/ObjectRegistry.php) that remembers found objects identities
+- an [item writer](https://github.com/yokai-php/batch-doctrine-persistence/blob/0.x/src/ObjectWriter.php) that persists objects through object manager
 
 
 ## Contribution

--- a/src/batch-league-flysystem/README.md
+++ b/src/batch-league-flysystem/README.md
@@ -22,10 +22,13 @@ composer require yokai/batch-league-flysystem
 
 ## Documentation
 
+Please read the [dedicated documentation page](https://yokai-batch.readthedocs.io/en/0.x/bridges/league-flysystem.html).
+
 This package provides:
 
-- a [job](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-league-flysystem/copy-files-job.md) that copy file(s) from one filesystem to another
-- a [job](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-league-flysystem/move-files-job.md) that move file(s) from one filesystem to another
+- a [job](https://github.com/yokai-php/batch-league-flysystem/blob/0.x/src/Job/CopyFilesJob.php) that copy file(s) from one filesystem to another
+- a [job](https://github.com/yokai-php/batch-league-flysystem/blob/0.x/src/Job/MoveFilesJob.php) that move file(s) from one filesystem to another
+- a [scheduler](https://github.com/yokai-php/batch-league-flysystem/blob/0.x/src/Scheduler/FileFoundScheduler.php) that triggers job when file is found on a filesystem
 
 
 ## Contribution

--- a/src/batch-openspout/README.md
+++ b/src/batch-openspout/README.md
@@ -22,10 +22,12 @@ composer require yokai/batch-openspout
 
 ## Documentation
 
+Please read the [dedicated documentation page](https://yokai-batch.readthedocs.io/en/0.x/bridges/openspout.html).
+
 This package provides:
 
-- a [item reader](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-openspout/flat-file-item-reader.md) that read from CSV/XLSX/ODS files
-- a [item writer](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-openspout/flat-file-item-writer.md) that write to CSV/XLSX/ODS files
+- an [item job reader](https://github.com/yokai-php/batch-openspout/blob/0.x/src/Reader/FlatFileReader.php) that read from CSV/XLSX/ODS files
+- an [item job writer](https://github.com/yokai-php/batch-openspout/blob/0.x/src/Writer/FlatFileWriter.php) that write to CSV/XLSX/ODS files
 
 
 ## Contribution

--- a/src/batch-symfony-console/README.md
+++ b/src/batch-symfony-console/README.md
@@ -22,10 +22,11 @@ composer require yokai/batch-symfony-console
 
 ## Documentation
 
+Please read the [dedicated documentation page](https://yokai-batch.readthedocs.io/en/0.x/bridges/symfony-console.html).
+
 This package provides:
 
-- a [job launcher](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-symfony-console/job-launcher.md) that uses command to launch jobs
-- a [command](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-symfony-console/command.md) to launch jobs
+- a [job launcher](https://github.com/yokai-php/batch-symfony-console/blob/0.x/src/RunCommandJobLauncher.php) that uses CLI command to launch jobs
 
 
 ## Contribution

--- a/src/batch-symfony-framework/README.md
+++ b/src/batch-symfony-framework/README.md
@@ -22,10 +22,9 @@ composer require yokai/batch-symfony-framework
 
 ## Documentation
 
-This package provides:
+Please read the [getting started documentation page](https://yokai-batch.readthedocs.io/en/0.x/getting-started/with-symfony.html).
 
-- [integration](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-symfony-framework/getting-started.md) with Symfony framework
-- a [UI](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-symfony-framework/ui.md) with Symfony framework
+Or the [dedicated documentation page](https://yokai-batch.readthedocs.io/en/0.x/bridges/symfony-framework.html).
 
 
 ## Contribution

--- a/src/batch-symfony-messenger/README.md
+++ b/src/batch-symfony-messenger/README.md
@@ -22,10 +22,12 @@ composer require yokai/batch-symfony-messenger
 
 ## Documentation
 
+Please read the [dedicated documentation page](https://yokai-batch.readthedocs.io/en/0.x/bridges/symfony-messenger.html).
+
 This package provides:
 
-- a [job launcher](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-symfony-messenger/job-launcher.md) that uses messages to launch jobs
-- a [writer](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-symfony-messenger/dispatch-each-item-writer.md) that will write each item as a message
+- a [job launcher](https://github.com/yokai-php/batch-symfony-messenger/blob/0.x/src/DispatchMessageJobLauncher.php) that uses messages to launch jobs
+- an [item job writer](https://github.com/yokai-php/batch-symfony-messenger/blob/0.x/src/Writer/DispatchEachItemAsMessageWriter.php) that will write each item as a message
 
 
 ## Contribution

--- a/src/batch-symfony-serializer/README.md
+++ b/src/batch-symfony-serializer/README.md
@@ -22,11 +22,12 @@ composer require yokai/batch-symfony-serializer
 
 ## Documentation
 
+Please read the [dedicated documentation page](https://yokai-batch.readthedocs.io/en/0.x/bridges/symfony-serializer.html).
+
 This package provides:
 
-- an [item processor](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-symfony-serializer/normalize-item-processor.md) that uses normalization
-- an [item processor](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-symfony-serializer/denormalize-item-processor.md) that uses denormalization
-- a [job execution serializer](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-symfony-serializer/job-execution-serializer.md) that uses serialization
+- an [item job processor](https://github.com/yokai-php/batch-symfony-serializer/blob/0.x/src/NormalizeItemProcessor.php) that normalizes every item
+- an [item job processor](https://github.com/yokai-php/batch-symfony-serializer/blob/0.x/src/DenormalizeItemProcessor.php) that denormalizes every item
 
 
 ## Contribution

--- a/src/batch-symfony-validator/README.md
+++ b/src/batch-symfony-validator/README.md
@@ -22,9 +22,11 @@ composer require yokai/batch-symfony-validator
 
 ## Documentation
 
+Please read the [dedicated documentation page](https://yokai-batch.readthedocs.io/en/0.x/bridges/symfony-validator.html).
+
 This package provides:
 
-- an [item processor](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch-symfony-validator/skip-invalid-item-processor.md) that skip invalid items
+- an [item job processor](https://github.com/yokai-php/batch-symfony-validator/blob/0.x/src/SkipInvalidItemProcessor.php) that skip invalid items
 
 
 ## Contribution

--- a/src/batch/README.md
+++ b/src/batch/README.md
@@ -30,12 +30,7 @@ composer require yokai/batch
 
 ## Documentation
 
-Let's [get started](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch/getting-started.md) around core concepts of this library.
-
-Looking for something in particular ?
-
-- [How to use *Aware interfaces ?](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch/recipes/aware-interfaces.md)
-- [Create your own job execution storage](https://github.com/yokai-php/batch-src/blob/0.x/docs/batch/recipes/custom-job-execution-storage.md)
+Please read the [getting started documentation page](https://yokai-batch.readthedocs.io/en/0.x/getting-started/standalone-library.html).
 
 Looking for something more specific ?
 
@@ -43,9 +38,9 @@ Looking for something more specific ?
 - [Read from Doctrine ORM entities](https://github.com/yokai-php/batch-doctrine-orm)
 - [Write to Doctrine ORM/ODM... objects](https://github.com/yokai-php/batch-doctrine-persistence)
 - [Copy/Move files in a job / Trigger job when file found](https://github.com/yokai-php/batch-league-flysystem)
-- [Trigger async jobs using CLI command](https://github.com/yokai-php/batch-symfony-console): 
+- [Trigger async jobs using CLI command](https://github.com/yokai-php/batch-symfony-console)
 - [Integration with Symfony framework](https://github.com/yokai-php/batch-symfony-framework)
-- [Trigger async jobs using using queue](https://github.com/yokai-php/batch-symfony-messenger): 
+- [Trigger async jobs using queue](https://github.com/yokai-php/batch-symfony-messenger)
 - [Normalize/Denormalize job items with](https://github.com/yokai-php/batch-symfony-serializer)
 - [Validate & Skip invalid items](https://github.com/yokai-php/batch-symfony-validator)
 


### PR DESCRIPTION
Since the documentation was moved to https://yokai-batch.readthedocs.io/
All the links that was still referencing markdown shattered in every repository must be replaced
Because the target urls doest not exists anymore