### PR TITLE
Replace deprecated implicitly nullable parameters with explicit null union type

### DIFF
--- a/.led/scripts/tests
+++ b/.led/scripts/tests
@@ -14,7 +14,7 @@ $composer = \array_filter(\explode(\PHP_EOL, $action['runs']['steps'][1]['run'])
 
 $io = new SymfonyStyle(new ArrayInput([]), new ConsoleOutput());
 
-$execute = function (array $job, string $php = null, string $symfony = null) use ($io, $composer) {
+$execute = function (array $job, string|null $php = null, string|null $symfony = null) use ($io, $composer) {
     $io->section($job['name']);
 
     if ($php === null && $symfony === null) {

--- a/src/batch-doctrine-dbal/src/DoctrineDBALInsertWriter.php
+++ b/src/batch-doctrine-dbal/src/DoctrineDBALInsertWriter.php
@@ -21,7 +21,7 @@ final class DoctrineDBALInsertWriter implements ItemWriterInterface
     public function __construct(
         ConnectionRegistry $doctrine,
         private string $table,
-        string $connection = null,
+        string|null $connection = null,
     ) {
         $connection ??= $doctrine->getDefaultConnectionName();
         /** @var Connection $connection */

--- a/src/batch-doctrine-dbal/src/DoctrineDBALQueryCursorReader.php
+++ b/src/batch-doctrine-dbal/src/DoctrineDBALQueryCursorReader.php
@@ -34,7 +34,7 @@ final class DoctrineDBALQueryCursorReader implements ItemReaderInterface
         private string $sql,
         private string $column,
         private mixed $start,
-        string $connection = null,
+        string|null $connection = null,
         private int $batch = 500,
     ) {
         if (!\str_contains($sql, '{after}') || !\str_contains($sql, '{limit}')) {

--- a/src/batch-doctrine-dbal/src/DoctrineDBALQueryOffsetReader.php
+++ b/src/batch-doctrine-dbal/src/DoctrineDBALQueryOffsetReader.php
@@ -21,8 +21,12 @@ final class DoctrineDBALQueryOffsetReader implements ItemReaderInterface
     private string $sql;
     private int $batch;
 
-    public function __construct(ConnectionRegistry $doctrine, string $sql, string $connection = null, int $batch = 500)
-    {
+    public function __construct(
+        ConnectionRegistry $doctrine,
+        string $sql,
+        string|null $connection = null,
+        int $batch = 500,
+    ) {
         if (\mb_strpos($sql, '{limit}') === false || \mb_strpos($sql, '{offset}') === false) {
             throw new InvalidArgumentException(
                 \sprintf('%s $sql argument must contains "{limit}" and "{offset}" for pagination.', __METHOD__),

--- a/src/batch-doctrine-dbal/src/DoctrineDBALUpsertWriter.php
+++ b/src/batch-doctrine-dbal/src/DoctrineDBALUpsertWriter.php
@@ -25,7 +25,7 @@ final class DoctrineDBALUpsertWriter implements
 
     private Connection $connection;
 
-    public function __construct(ConnectionRegistry $doctrine, string $connection = null)
+    public function __construct(ConnectionRegistry $doctrine, string|null $connection = null)
     {
         $connection ??= $doctrine->getDefaultConnectionName();
         /** @var Connection $connection */

--- a/src/batch-doctrine-dbal/src/JobExecutionRowNormalizer.php
+++ b/src/batch-doctrine-dbal/src/JobExecutionRowNormalizer.php
@@ -53,7 +53,7 @@ final class JobExecutionRowNormalizer
      *
      * @param array<string, mixed> $data
      */
-    public function fromRow(array $data, JobExecution $parent = null): JobExecution
+    public function fromRow(array $data, JobExecution|null $parent = null): JobExecution
     {
         $data['status'] = \intval($data['status']);
         $data['parameters'] = $this->jsonFromString($data['parameters']);

--- a/src/batch-doctrine-persistence/src/ObjectRegistry.php
+++ b/src/batch-doctrine-persistence/src/ObjectRegistry.php
@@ -58,7 +58,7 @@ final class ObjectRegistry
      *
      * @return T|null
      */
-    public function findOneUsing(string $class, \Closure $closure, string $key = null): null|object
+    public function findOneUsing(string $class, \Closure $closure, string|null $key = null): null|object
     {
         $manager = $this->doctrine->getManagerForClass($class);
         if ($manager === null) {

--- a/src/batch-doctrine-persistence/tests/Dummy/FindOneByCalledOnlyOnceWhenFoundRepositoryDecorator.php
+++ b/src/batch-doctrine-persistence/tests/Dummy/FindOneByCalledOnlyOnceWhenFoundRepositoryDecorator.php
@@ -25,7 +25,7 @@ class FindOneByCalledOnlyOnceWhenFoundRepositoryDecorator implements ObjectRepos
         return $this->decorated->findAll();
     }
 
-    public function findBy(array $criteria, null|array $orderBy = null, $limit = null, $offset = null)
+    public function findBy(array $criteria, array|null $orderBy = null, $limit = null, $offset = null)
     {
         return $this->decorated->findBy($criteria, $orderBy, $limit, $offset);
     }

--- a/src/batch-league-flysystem/src/Job/CopyFilesJob.php
+++ b/src/batch-league-flysystem/src/Job/CopyFilesJob.php
@@ -24,7 +24,7 @@ class CopyFilesJob implements JobInterface
         private JobParameterAccessorInterface $location,
         private FilesystemReader $source,
         private FilesystemWriter $destination,
-        private null|Closure $transformLocation = null,
+        private Closure|null $transformLocation = null,
     ) {
     }
 

--- a/src/batch-league-flysystem/src/Job/MoveFilesJob.php
+++ b/src/batch-league-flysystem/src/Job/MoveFilesJob.php
@@ -25,7 +25,7 @@ class MoveFilesJob implements JobInterface
         private JobParameterAccessorInterface $location,
         private FilesystemOperator $source,
         private FilesystemWriter $destination,
-        private null|Closure $transformLocation = null,
+        private Closure|null $transformLocation = null,
     ) {
     }
 

--- a/src/batch-openspout/src/Reader/FlatFileReader.php
+++ b/src/batch-openspout/src/Reader/FlatFileReader.php
@@ -37,8 +37,8 @@ final class FlatFileReader implements
     public function __construct(
         private JobParameterAccessorInterface $filePath,
         private CSVOptions|ODSOptions|XLSXOptions|null $options = null,
-        SheetFilter $sheetFilter = null,
-        HeaderStrategy $headerStrategy = null,
+        SheetFilter|null $sheetFilter = null,
+        HeaderStrategy|null $headerStrategy = null,
     ) {
         $this->sheetFilter = $sheetFilter ?? SheetFilter::all();
         $this->headerStrategy = $headerStrategy ?? HeaderStrategy::none();

--- a/src/batch-openspout/src/Reader/HeaderStrategy.php
+++ b/src/batch-openspout/src/Reader/HeaderStrategy.php
@@ -32,7 +32,7 @@ final class HeaderStrategy
      *
      * @param list<string>|null $headers
      */
-    public static function skip(array $headers = null): self
+    public static function skip(array|null $headers = null): self
     {
         return new self(self::SKIP, $headers);
     }
@@ -50,7 +50,7 @@ final class HeaderStrategy
      *
      * @param list<string>|null $headers
      */
-    public static function none(array $headers = null): self
+    public static function none(array|null $headers = null): self
     {
         return new self(self::NONE, $headers);
     }

--- a/src/batch-openspout/src/Writer/FlatFileWriter.php
+++ b/src/batch-openspout/src/Writer/FlatFileWriter.php
@@ -36,7 +36,7 @@ final class FlatFileWriter implements
 {
     use JobExecutionAwareTrait;
 
-    private null|WriterInterface $writer = null;
+    private WriterInterface|null $writer = null;
     private bool $headersAdded = false;
 
     public function __construct(
@@ -46,7 +46,7 @@ final class FlatFileWriter implements
         /**
          * @var list<string>|null
          */
-        private null|array $headers = null,
+        private array|null $headers = null,
     ) {
     }
 

--- a/src/batch-openspout/src/Writer/WriteToSheetItem.php
+++ b/src/batch-openspout/src/Writer/WriteToSheetItem.php
@@ -24,7 +24,7 @@ final class WriteToSheetItem
      *
      * @param array<int, bool|\DateInterval|\DateTimeInterface|float|int|string> $item
      */
-    public static function array(string $sheet, array $item, Style $style = null): self
+    public static function array(string $sheet, array $item, Style|null $style = null): self
     {
         return new self($sheet, Row::fromValues($item, $style));
     }

--- a/src/batch-symfony-console/src/CommandRunner.php
+++ b/src/batch-symfony-console/src/CommandRunner.php
@@ -18,7 +18,7 @@ class CommandRunner
     public function __construct(
         string $binDir,
         private string $logDir,
-        PhpExecutableFinder $phpLocator = null,
+        PhpExecutableFinder|null $phpLocator = null,
     ) {
         $this->consolePath = \implode(DIRECTORY_SEPARATOR, [$binDir, 'console']);
         if (\class_exists(PhpExecutableFinder::class)) {

--- a/src/batch-symfony-console/tests/RunJobCommandTest.php
+++ b/src/batch-symfony-console/tests/RunJobCommandTest.php
@@ -156,8 +156,10 @@ class RunJobCommandTest extends TestCase
         yield 'debug' => [OutputInterface::VERBOSITY_DEBUG];
     }
 
-    private function execute(string $configuration = null, int $verbosity = OutputInterface::VERBOSITY_NORMAL): array
-    {
+    private function execute(
+        string|null $configuration = null,
+        int $verbosity = OutputInterface::VERBOSITY_NORMAL,
+    ): array {
         $options = ['verbosity' => $verbosity];
         $input = ['job' => self::JOBNAME];
         if ($configuration !== null) {

--- a/src/batch-symfony-framework/src/UserInterface/Controller/JobController.php
+++ b/src/batch-symfony-framework/src/UserInterface/Controller/JobController.php
@@ -136,7 +136,7 @@ final class JobController
     /**
      * View {@see JobExecution} details in a Twig template.
      */
-    public function view(string $job, string $id, null|string $path = null): Response
+    public function view(string $job, string $id, string|null $path = null): Response
     {
         try {
             $execution = $this->jobExecutionStorage->retrieve($job, $id);

--- a/src/batch-symfony-serializer/src/DenormalizeItemProcessor.php
+++ b/src/batch-symfony-serializer/src/DenormalizeItemProcessor.php
@@ -18,7 +18,7 @@ final class DenormalizeItemProcessor implements ItemProcessorInterface
     public function __construct(
         private DenormalizerInterface $denormalizer,
         private string $type,
-        private null|string $format = null,
+        private string|null $format = null,
         /**
          * @var array<string, mixed>
          */

--- a/src/batch-symfony-serializer/src/NormalizeItemProcessor.php
+++ b/src/batch-symfony-serializer/src/NormalizeItemProcessor.php
@@ -17,7 +17,7 @@ final class NormalizeItemProcessor implements ItemProcessorInterface
 {
     public function __construct(
         private NormalizerInterface $normalizer,
-        private null|string $format = null,
+        private string|null $format = null,
         /**
          * @var array<string, mixed>
          */

--- a/src/batch-symfony-serializer/tests/Dummy/DummyNormalizer.php
+++ b/src/batch-symfony-serializer/tests/Dummy/DummyNormalizer.php
@@ -15,25 +15,29 @@ final class DummyNormalizer implements NormalizerInterface, DenormalizerInterfac
     ) {
     }
 
-    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    public function supportsNormalization(mixed $data, string|null $format = null, array $context = []): bool
     {
         return $this->supports;
     }
 
     public function normalize(
         mixed $object,
-        string $format = null,
+        string|null $format = null,
         array $context = [],
     ): array|string|int|float|bool|\ArrayObject|null {
         return $this->value;
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
-    {
+    public function supportsDenormalization(
+        mixed $data,
+        string $type,
+        string|null $format = null,
+        array $context = [],
+    ): bool {
         return $this->supports;
     }
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, string|null $format = null, array $context = []): mixed
     {
         return $this->value;
     }

--- a/src/batch-symfony-serializer/tests/Dummy/FailingNormalizer.php
+++ b/src/batch-symfony-serializer/tests/Dummy/FailingNormalizer.php
@@ -15,25 +15,29 @@ final class FailingNormalizer implements NormalizerInterface, DenormalizerInterf
     ) {
     }
 
-    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    public function supportsNormalization(mixed $data, string|null $format = null, array $context = []): bool
     {
         return true;
     }
 
     public function normalize(
         mixed $object,
-        string $format = null,
+        string|null $format = null,
         array $context = [],
     ): array|string|int|float|bool|\ArrayObject|null {
         throw $this->exception;
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
-    {
+    public function supportsDenormalization(
+        mixed $data,
+        string $type,
+        string|null $format = null,
+        array $context = [],
+    ): bool {
         return true;
     }
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, string|null $format = null, array $context = []): mixed
     {
         throw $this->exception;
     }

--- a/src/batch-symfony-validator/src/SkipInvalidItemProcessor.php
+++ b/src/batch-symfony-validator/src/SkipInvalidItemProcessor.php
@@ -21,11 +21,11 @@ final class SkipInvalidItemProcessor implements ItemProcessorInterface
         /**
          * @var Constraint[]|null
          */
-        private null|array $contraints = null,
+        private array|null $contraints = null,
         /**
          * @var string[]|null
          */
-        private null|array $groups = null,
+        private array|null $groups = null,
     ) {
     }
 

--- a/src/batch/src/Exception/BadMethodCallException.php
+++ b/src/batch/src/Exception/BadMethodCallException.php
@@ -9,7 +9,7 @@ use Yokai\Batch\Job\Item\InitializableInterface;
 
 class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface
 {
-    public function __construct(string $message = '', Throwable $previous = null)
+    public function __construct(string $message = '', Throwable|null $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/src/batch/src/Exception/CannotRemoveJobExecutionException.php
+++ b/src/batch/src/Exception/CannotRemoveJobExecutionException.php
@@ -8,7 +8,7 @@ use Throwable;
 
 class CannotRemoveJobExecutionException extends RuntimeException
 {
-    public function __construct(string $jobName, string $executionId, Throwable $previous = null)
+    public function __construct(string $jobName, string $executionId, Throwable|null $previous = null)
     {
         parent::__construct(
             \sprintf('Cannot remove job execution "%s" of job "%s"', $executionId, $jobName),

--- a/src/batch/src/Exception/CannotStoreJobExecutionException.php
+++ b/src/batch/src/Exception/CannotStoreJobExecutionException.php
@@ -8,7 +8,7 @@ use Throwable;
 
 class CannotStoreJobExecutionException extends RuntimeException
 {
-    public function __construct(string $jobName, string $executionId, Throwable $previous = null)
+    public function __construct(string $jobName, string $executionId, Throwable|null $previous = null)
     {
         parent::__construct(
             \sprintf('Cannot store job execution "%s" of job "%s"', $executionId, $jobName),

--- a/src/batch/src/Exception/InvalidArgumentException.php
+++ b/src/batch/src/Exception/InvalidArgumentException.php
@@ -8,7 +8,7 @@ use Throwable;
 
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
-    public function __construct(string $message = '', Throwable $previous = null)
+    public function __construct(string $message = '', Throwable|null $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/src/batch/src/Exception/JobExecutionNotFoundException.php
+++ b/src/batch/src/Exception/JobExecutionNotFoundException.php
@@ -8,7 +8,7 @@ use Throwable;
 
 class JobExecutionNotFoundException extends \InvalidArgumentException implements ExceptionInterface
 {
-    public function __construct(string $jobName, string $executionId, Throwable $previous = null)
+    public function __construct(string $jobName, string $executionId, Throwable|null $previous = null)
     {
         parent::__construct(
             \sprintf('Job execution "%s" of job "%s" cannot be found', $executionId, $jobName),

--- a/src/batch/src/Exception/LogicException.php
+++ b/src/batch/src/Exception/LogicException.php
@@ -8,7 +8,7 @@ use Throwable;
 
 class LogicException extends \LogicException implements ExceptionInterface
 {
-    public function __construct(string $message = '', Throwable $previous = null)
+    public function __construct(string $message = '', Throwable|null $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/src/batch/src/Exception/RuntimeException.php
+++ b/src/batch/src/Exception/RuntimeException.php
@@ -8,12 +8,12 @@ use Throwable;
 
 class RuntimeException extends \RuntimeException implements ExceptionInterface
 {
-    public function __construct(string $message = '', Throwable $previous = null)
+    public function __construct(string $message = '', Throwable|null $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }
 
-    public static function error(Throwable $error, string $message = null): self
+    public static function error(Throwable $error, string|null $message = null): self
     {
         return new self(\sprintf('%sAn error occurred.', $message ? \rtrim($message, '. ') . '. ' : ''), $error);
     }

--- a/src/batch/src/Exception/UndefinedJobException.php
+++ b/src/batch/src/Exception/UndefinedJobException.php
@@ -8,7 +8,7 @@ use Throwable;
 
 class UndefinedJobException extends InvalidArgumentException
 {
-    public function __construct(string $name, Throwable $previous = null)
+    public function __construct(string $name, Throwable|null $previous = null)
     {
         parent::__construct(\sprintf('Job "%s" is undefined', $name), $previous);
     }

--- a/src/batch/src/Exception/UnexpectedValueException.php
+++ b/src/batch/src/Exception/UnexpectedValueException.php
@@ -8,12 +8,12 @@ use Throwable;
 
 class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
 {
-    public function __construct(string $base = null, string $message = '', Throwable $previous = null)
+    public function __construct(string|null $base = null, string $message = '', Throwable|null $previous = null)
     {
         parent::__construct(($base ? \rtrim($base, '. ') . '. ' : '') . $message, 0, $previous);
     }
 
-    public static function type(string $expected, mixed $argument, string $message = null): self
+    public static function type(string $expected, mixed $argument, string|null $message = null): self
     {
         return new self(
             $message,
@@ -24,7 +24,7 @@ class UnexpectedValueException extends \UnexpectedValueException implements Exce
     /**
      * @param mixed[] $expected
      */
-    public static function enum(array $expected, mixed $argument, string $message = null): self
+    public static function enum(array $expected, mixed $argument, string|null $message = null): self
     {
         return new self(
             $message,
@@ -36,12 +36,12 @@ class UnexpectedValueException extends \UnexpectedValueException implements Exce
         );
     }
 
-    public static function min(float|int|null $min, float|int|null $argument, string $message = null): self
+    public static function min(float|int|null $min, float|int|null $argument, string|null $message = null): self
     {
         return new self($message, \sprintf('Expecting argument to be %s or more, got %s.', $min, $argument));
     }
 
-    public static function date(string $expected, mixed $argument, string $message = null): self
+    public static function date(string $expected, mixed $argument, string|null $message = null): self
     {
         return new self(
             $message,

--- a/src/batch/src/Job/JobWithChildJobs.php
+++ b/src/batch/src/Job/JobWithChildJobs.php
@@ -37,7 +37,7 @@ class JobWithChildJobs implements JobInterface
     public static function withAnonymousChildren(
         array $children,
         JobExecutionStorageInterface $executionStorage,
-        EventDispatcherInterface $eventDispatcher = null,
+        EventDispatcherInterface|null $eventDispatcher = null,
     ): self {
         return new self(
             $executionStorage,

--- a/src/batch/src/JobExecution.php
+++ b/src/batch/src/JobExecution.php
@@ -124,10 +124,10 @@ final class JobExecution
     public static function createRoot(
         string $id,
         string $jobName,
-        BatchStatus $status = null,
-        JobParameters $parameters = null,
-        Summary $summary = null,
-        JobExecutionLogs $logs = null,
+        BatchStatus|null $status = null,
+        JobParameters|null $parameters = null,
+        Summary|null $summary = null,
+        JobExecutionLogs|null $logs = null,
     ): self {
         return new self(null, $id, $jobName, $status, $parameters, $summary, $logs);
     }
@@ -138,9 +138,9 @@ final class JobExecution
     public static function createChild(
         JobExecution $parent,
         string $jobName,
-        BatchStatus $status = null,
-        JobParameters $parameters = null,
-        Summary $summary = null,
+        BatchStatus|null $status = null,
+        JobParameters|null $parameters = null,
+        Summary|null $summary = null,
     ): self {
         return new self($parent, $parent->getId(), $jobName, $status, $parameters, $summary, null);
     }
@@ -387,7 +387,7 @@ final class JobExecution
      * @param string|null $message The message to use while logging
      * @param LogLevel::* $level The level to use while logging
      */
-    public function logError(Throwable $error, string $message = null, string $level = LogLevel::ERROR): void
+    public function logError(Throwable $error, string|null $message = null, string $level = LogLevel::ERROR): void
     {
         $this->logger->log($level, $message ?? 'An error occurred', ['error' => (string)$error]);
     }

--- a/src/batch/src/Serializer/JsonJobExecutionSerializer.php
+++ b/src/batch/src/Serializer/JsonJobExecutionSerializer.php
@@ -84,7 +84,7 @@ final class JsonJobExecutionSerializer implements JobExecutionSerializerInterfac
     /**
      * @param array<string, mixed> $jobExecutionData
      */
-    private function fromArray(array $jobExecutionData, JobExecution $parentExecution = null): JobExecution
+    private function fromArray(array $jobExecutionData, JobExecution|null $parentExecution = null): JobExecution
     {
         $name = $jobExecutionData['jobName'];
         $status = new BatchStatus($jobExecutionData['status']);

--- a/src/batch/tests/Storage/FilesystemJobExecutionStorageTest.php
+++ b/src/batch/tests/Storage/FilesystemJobExecutionStorageTest.php
@@ -50,7 +50,7 @@ class FilesystemJobExecutionStorageTest extends TestCase
 
     private function createStorage(
         string $dir = self::STORAGE_DIR,
-        JobExecutionSerializerInterface $serializer = null,
+        JobExecutionSerializerInterface|null $serializer = null,
     ): FilesystemJobExecutionStorage {
         return new FilesystemJobExecutionStorage(
             $serializer ?? $this->serializer->reveal(),

--- a/tests/symfony/tests/JobAssert.php
+++ b/tests/symfony/tests/JobAssert.php
@@ -22,7 +22,7 @@ final class JobAssert
         int $read,
         int $processed,
         int $write,
-        int $skipped = null,
+        int|null $skipped = null,
     ): void {
         Assert::assertSame($read, $execution->getSummary()->get('read'));
         Assert::assertSame($processed, $execution->getSummary()->get('processed'));


### PR DESCRIPTION
PHP 8.4 has deprecated implicitly nullable parameter types.
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

All implicitly nullable parameters, must now have the explicit `|null` union type instead.

```diff
-function bar(int $x = null) {
+function bar(int|null $x = null) {
}
```