### PR TITLE
Do not perform service checks on non registered services

### DIFF
--- a/src/batch-symfony-framework/src/DependencyInjection/CompilerPass/ConfigureTemplatingPass.php
+++ b/src/batch-symfony-framework/src/DependencyInjection/CompilerPass/ConfigureTemplatingPass.php
@@ -17,6 +17,10 @@ final class ConfigureTemplatingPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
+        if (!$container->hasAlias(TemplatingInterface::class)) {
+            return;
+        }
+
         $templatingActualService = (string)$container->getAlias(TemplatingInterface::class);
 
         try {

--- a/src/batch-symfony-framework/tests/DependencyInjection/CompilerPass/ConfigureTemplatingPassTest.php
+++ b/src/batch-symfony-framework/tests/DependencyInjection/CompilerPass/ConfigureTemplatingPassTest.php
@@ -23,6 +23,14 @@ final class ConfigureTemplatingPassTest extends TestCase
         self::assertTrue(true, 'No exception was raised');
     }
 
+    public function testMissingAlias(): void
+    {
+        $this->process(function (ContainerBuilder $container) {
+        });
+
+        self::assertTrue(true, 'No exception was raised');
+    }
+
     public function testMissingService(): void
     {
         $this->expectExceptionObject(


### PR DESCRIPTION
Integrity checks are performed on TemplatingInterface service in a compiler pass.

Do not perform these checks if the service alias is not registered.