### PR TITLE
Fixed using missing alias in compiler pass & add test

### DIFF
--- a/src/batch-symfony-framework/src/DependencyInjection/CompilerPass/ConfigureTemplatingPass.php
+++ b/src/batch-symfony-framework/src/DependencyInjection/CompilerPass/ConfigureTemplatingPass.php
@@ -17,6 +17,10 @@ final class ConfigureTemplatingPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
+        if (!$container->hasAlias(TemplatingInterface::class)) {
+            return;
+        }
+
         $templatingActualService = (string)$container->getAlias(TemplatingInterface::class);
 
         try {

--- a/src/batch-symfony-framework/tests/DependencyInjection/YokaiBatchExtensionTest.php
+++ b/src/batch-symfony-framework/tests/DependencyInjection/YokaiBatchExtensionTest.php
@@ -18,6 +18,7 @@ use Yokai\Batch\Bridge\Symfony\Framework\DependencyInjection\YokaiBatchExtension
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Templating\ConfigurableTemplating;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Templating\SonataAdminTemplating;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Templating\TemplatingInterface;
+use Yokai\Batch\Bridge\Symfony\Framework\YokaiBatchBundle;
 use Yokai\Batch\Bridge\Symfony\Messenger\DispatchMessageJobLauncher;
 use Yokai\Batch\Bridge\Symfony\Uid\Factory\RandomBasedUuidJobExecutionIdGenerator;
 use Yokai\Batch\Bridge\Symfony\Uid\Factory\TimeBasedUuidJobExecutionIdGenerator;
@@ -423,12 +424,16 @@ class YokaiBatchExtensionTest extends TestCase
         if ($configure !== null) {
             $configure($container);
         }
-        $container->registerExtension(new YokaiBatchExtension());
+        $bundle = new YokaiBatchBundle();
+        $extension = $bundle->getContainerExtension();
+        \assert($extension instanceof YokaiBatchExtension);
+        $container->registerExtension($extension);
         $container->loadFromExtension('yokai_batch', $config);
 
         $container->getCompilerPassConfig()->setOptimizationPasses([]);
         $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->getCompilerPassConfig()->setAfterRemovingPasses([]);
+        $bundle->build($container);
         $container->compile();
 
         return $container;


### PR DESCRIPTION
Replace #165

The `TemplatingInterface` alias might not exists
But the tests did not cover that use case
Updated the tests accordingly to avoid having the same issue later