### PR TITLE
Add package separator in bridge documentation

### DIFF
--- a/docs/docs/bridges.rst
+++ b/docs/docs/bridges.rst
@@ -3,7 +3,7 @@ Bridges
 
 | ``yokai/batch`` has no dependency on itself.
 | But it is part of a larger package ecosystem, that are bridges with popular libraries and frameworks.
-| Everytime you add a ``yokai/batch*`` package to your project, you gain more capabilities in jobs development.
+| Everytime you add a ``yokai/batch-*`` package to your project, you gain more capabilities in jobs development.
 
 Here is the complete list of what to expect:
 


### PR DESCRIPTION
Hi @yann-eugone, I'm not sure, but it seems to me there's a “-” missing from your syntax.