### PR TITLE
Update lockdown Github actions to v4

### DIFF
--- a/docs/.github/workflows/lockdown.yml
+++ b/docs/.github/workflows/lockdown.yml
@@ -8,7 +8,7 @@ jobs:
   lockdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/repo-lockdown@v2
+      - uses: dessant/repo-lockdown@v4
         with:
           github-token: ${{ github.token }}
           close-pr: true

--- a/src/batch-doctrine-dbal/.github/workflows/lockdown.yml
+++ b/src/batch-doctrine-dbal/.github/workflows/lockdown.yml
@@ -8,7 +8,7 @@ jobs:
   lockdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/repo-lockdown@v2
+      - uses: dessant/repo-lockdown@v4
         with:
           github-token: ${{ github.token }}
           close-pr: true

--- a/src/batch-doctrine-orm/.github/workflows/lockdown.yml
+++ b/src/batch-doctrine-orm/.github/workflows/lockdown.yml
@@ -8,7 +8,7 @@ jobs:
   lockdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/repo-lockdown@v2
+      - uses: dessant/repo-lockdown@v4
         with:
           github-token: ${{ github.token }}
           close-pr: true

--- a/src/batch-doctrine-persistence/.github/workflows/lockdown.yml
+++ b/src/batch-doctrine-persistence/.github/workflows/lockdown.yml
@@ -8,7 +8,7 @@ jobs:
   lockdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/repo-lockdown@v2
+      - uses: dessant/repo-lockdown@v4
         with:
           github-token: ${{ github.token }}
           close-pr: true

--- a/src/batch-league-flysystem/.github/workflows/lockdown.yml
+++ b/src/batch-league-flysystem/.github/workflows/lockdown.yml
@@ -8,7 +8,7 @@ jobs:
   lockdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/repo-lockdown@v2
+      - uses: dessant/repo-lockdown@v4
         with:
           github-token: ${{ github.token }}
           close-pr: true

--- a/src/batch-openspout/.github/workflows/lockdown.yml
+++ b/src/batch-openspout/.github/workflows/lockdown.yml
@@ -8,7 +8,7 @@ jobs:
   lockdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/repo-lockdown@v2
+      - uses: dessant/repo-lockdown@v4
         with:
           github-token: ${{ github.token }}
           close-pr: true

--- a/src/batch-symfony-console/.github/workflows/lockdown.yml
+++ b/src/batch-symfony-console/.github/workflows/lockdown.yml
@@ -8,7 +8,7 @@ jobs:
   lockdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/repo-lockdown@v2
+      - uses: dessant/repo-lockdown@v4
         with:
           github-token: ${{ github.token }}
           close-pr: true

--- a/src/batch-symfony-framework/.github/workflows/lockdown.yml
+++ b/src/batch-symfony-framework/.github/workflows/lockdown.yml
@@ -8,7 +8,7 @@ jobs:
   lockdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/repo-lockdown@v2
+      - uses: dessant/repo-lockdown@v4
         with:
           github-token: ${{ github.token }}
           close-pr: true

--- a/src/batch-symfony-messenger/.github/workflows/lockdown.yml
+++ b/src/batch-symfony-messenger/.github/workflows/lockdown.yml
@@ -8,7 +8,7 @@ jobs:
   lockdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/repo-lockdown@v2
+      - uses: dessant/repo-lockdown@v4
         with:
           github-token: ${{ github.token }}
           close-pr: true

--- a/src/batch-symfony-pack/.github/workflows/lockdown.yml
+++ b/src/batch-symfony-pack/.github/workflows/lockdown.yml
@@ -8,7 +8,7 @@ jobs:
   lockdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/repo-lockdown@v2
+      - uses: dessant/repo-lockdown@v4
         with:
           github-token: ${{ github.token }}
           close-pr: true

--- a/src/batch-symfony-serializer/.github/workflows/lockdown.yml
+++ b/src/batch-symfony-serializer/.github/workflows/lockdown.yml
@@ -8,7 +8,7 @@ jobs:
   lockdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/repo-lockdown@v2
+      - uses: dessant/repo-lockdown@v4
         with:
           github-token: ${{ github.token }}
           close-pr: true

--- a/src/batch-symfony-uid/.github/workflows/lockdown.yml
+++ b/src/batch-symfony-uid/.github/workflows/lockdown.yml
@@ -8,7 +8,7 @@ jobs:
   lockdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/repo-lockdown@v2
+      - uses: dessant/repo-lockdown@v4
         with:
           github-token: ${{ github.token }}
           close-pr: true

--- a/src/batch-symfony-validator/.github/workflows/lockdown.yml
+++ b/src/batch-symfony-validator/.github/workflows/lockdown.yml
@@ -8,7 +8,7 @@ jobs:
   lockdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/repo-lockdown@v2
+      - uses: dessant/repo-lockdown@v4
         with:
           github-token: ${{ github.token }}
           close-pr: true

--- a/src/batch/.github/workflows/lockdown.yml
+++ b/src/batch/.github/workflows/lockdown.yml
@@ -8,7 +8,7 @@ jobs:
   lockdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/repo-lockdown@v2
+      - uses: dessant/repo-lockdown@v4
         with:
           github-token: ${{ github.token }}
           close-pr: true


### PR DESCRIPTION
Lockdown seems to fail
https://github.com/yokai-php/batch-documentation/pull/1

Trying to update from `v2` to `v4`