### PR TITLE
Bump testing versions to PHP 8.4 & Symfony 7.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,12 +15,12 @@ jobs:
         include:
           - php-version: '8.1'
             symfony-version: '6.4.*'
-          - php-version: '8.3'
+          - php-version: '8.4'
             symfony-version: '6.4.*'
           - php-version: '8.2'
-            symfony-version: '7.0.*'
-          - php-version: '8.3'
-            symfony-version: '7.0.*'
+            symfony-version: '7.3.*'
+          - php-version: '8.4'
+            symfony-version: '7.3.*'
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
@@ -41,8 +41,8 @@ jobs:
       - name: "Setup env & install dependencies"
         uses: ./.github/actions/install
         with:
-          php-version: '8.3'
-          symfony-version: '7.0.*'
+          php-version: '8.4'
+          symfony-version: '7.3.*'
       - name: "Run static analyzis with phpstan/phpstan"
         run: vendor/bin/phpstan analyze
 
@@ -55,8 +55,8 @@ jobs:
       - name: "Setup env & install dependencies"
         uses: ./.github/actions/install
         with:
-          php-version: '8.3'
-          symfony-version: '7.0.*'
+          php-version: '8.4'
+          symfony-version: '7.3.*'
       - name: "Run checkstyle with symplify/easy-coding-standard"
         run: vendor/bin/ecs
 
@@ -69,8 +69,8 @@ jobs:
       - name: "Setup env & install dependencies"
         uses: ./.github/actions/install
         with:
-          php-version: '8.3'
-          symfony-version: '7.0.*'
+          php-version: '8.4'
+          symfony-version: '7.3.*'
       - name: "Run tests with phpunit/phpunit"
         run: vendor/bin/phpunit --testsuite=Convention
 
@@ -84,8 +84,8 @@ jobs:
       - name: "Setup env & install dependencies"
         uses: ./.github/actions/install
         with:
-          php-version: '8.3'
-          symfony-version: '7.0.*'
+          php-version: '8.4'
+          symfony-version: '7.3.*'
           coverage-mode: 'xdebug'
       - name: "Run tests with phpunit/phpunit"
         run: |


### PR DESCRIPTION
Bump testing versions
- PHP 8.3 => 8.4
- Symfony 7.0 => 7.3