### PR TITLE
Fix CI

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -33,6 +33,7 @@ runs:
         composer require --quiet --no-update "symfony/messenger:${{ inputs.symfony-version }}"
         composer require --quiet --no-update "symfony/process:${{ inputs.symfony-version }}"
         composer require --quiet --no-update "symfony/serializer:${{ inputs.symfony-version }}"
+        composer require --quiet --no-update "symfony/property-info:${{ inputs.symfony-version }}"
         composer require --quiet --no-update "symfony/validator:${{ inputs.symfony-version }}"
         composer require --quiet --no-update "symfony/filesystem:${{ inputs.symfony-version }}" --dev
         composer require --quiet --no-update "symfony/finder:${{ inputs.symfony-version }}" --dev

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -30,6 +30,7 @@ runs:
       run: |
         composer require --quiet --no-update "symfony/console:${{ inputs.symfony-version }}"
         composer require --quiet --no-update "symfony/framework-bundle:${{ inputs.symfony-version }}"
+        composer require --quiet --no-update "symfony/routing:${{ inputs.symfony-version }}"
         composer require --quiet --no-update "symfony/messenger:${{ inputs.symfony-version }}"
         composer require --quiet --no-update "symfony/process:${{ inputs.symfony-version }}"
         composer require --quiet --no-update "symfony/serializer:${{ inputs.symfony-version }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,9 @@ jobs:
           - php-version: '8.4'
             symfony-version: '6.4.*'
           - php-version: '8.2'
-            symfony-version: '7.3.*'
+            symfony-version: '7.4.*'
           - php-version: '8.4'
-            symfony-version: '7.3.*'
+            symfony-version: '7.4.*'
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
         uses: ./.github/actions/install
         with:
           php-version: '8.4'
-          symfony-version: '7.3.*'
+          symfony-version: '7.4.*'
       - name: "Run static analyzis with phpstan/phpstan"
         run: vendor/bin/phpstan analyze
 
@@ -56,7 +56,7 @@ jobs:
         uses: ./.github/actions/install
         with:
           php-version: '8.4'
-          symfony-version: '7.3.*'
+          symfony-version: '7.4.*'
       - name: "Run checkstyle with symplify/easy-coding-standard"
         run: vendor/bin/ecs
 
@@ -70,7 +70,7 @@ jobs:
         uses: ./.github/actions/install
         with:
           php-version: '8.4'
-          symfony-version: '7.3.*'
+          symfony-version: '7.4.*'
       - name: "Run tests with phpunit/phpunit"
         run: vendor/bin/phpunit --testsuite=Convention
 
@@ -85,7 +85,7 @@ jobs:
         uses: ./.github/actions/install
         with:
           php-version: '8.4'
-          symfony-version: '7.3.*'
+          symfony-version: '7.4.*'
           coverage-mode: 'xdebug'
       - name: "Run tests with phpunit/phpunit"
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,21 @@
 services:
+  php84:
+    container_name: yokai-batch-php84
+    extends:
+      file: $HOME/.led/docker-base.yaml
+      service: localuser
+    hostname: php84
+    image: ledup/php:8.4-rl9
+    volumes:
+      - .:/src
+    working_dir: /src
   php83:
     container_name: yokai-batch-php83
     extends:
       file: $HOME/.led/docker-base.yaml
       service: localuser
     hostname: php83
-    image: ledup/php:8.3
+    image: ledup/php:8.3-rl9
     volumes:
       - .:/src
     working_dir: /src
@@ -15,7 +25,7 @@ services:
       file: $HOME/.led/docker-base.yaml
       service: localuser
     hostname: php82
-    image: ledup/php:8.2
+    image: ledup/php:8.2-rl9
     volumes:
       - .:/src
     working_dir: /src
@@ -25,7 +35,7 @@ services:
       file: $HOME/.led/docker-base.yaml
       service: localuser
     hostname: php81
-    image: ledup/php:8.1
+    image: ledup/php:8.1-rl9
     volumes:
       - .:/src
     working_dir: /src

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -161,11 +161,6 @@ parameters:
 			path: src/batch-openspout/src/Writer/FlatFileWriter.php
 
 		-
-			message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeDefinition\\:\\:children\\(\\)\\.$#"
-			count: 1
-			path: src/batch-symfony-framework/src/DependencyInjection/Configuration.php
-
-		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
 			count: 3
 			path: src/batch/src/Serializer/JsonJobExecutionSerializer.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,8 +15,3 @@ parameters:
     - src/batch-symfony-messenger/src/
     - src/batch-symfony-serializer/src/
     - src/batch-symfony-validator/src/
-
-  ignoreErrors:
-    # The DependencyInjection returns are complex to deal with
-    - message: '#^Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface\:\:#'
-      path: ./src/batch-symfony-framework/src/DependencyInjection/Configuration.php

--- a/src/batch-symfony-framework/tests/UserInterface/Controller/JobControllerTest.php
+++ b/src/batch-symfony-framework/tests/UserInterface/Controller/JobControllerTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
 use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
@@ -418,8 +419,11 @@ final class JobControllerTest extends TestCase
                         {
                         }
 
-                        public function isGranted(mixed $attribute, mixed $subject = null): bool
-                        {
+                        public function isGranted(
+                            mixed $attribute,
+                            mixed $subject = null,
+                            AccessDecision|null $accessDecision = null,
+                        ): bool {
                             return $this->granted;
                         }
                     },

--- a/src/batch-symfony-framework/tests/UserInterface/JobSecurityTest.php
+++ b/src/batch-symfony-framework/tests/UserInterface/JobSecurityTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yokai\Batch\Tests\Bridge\Symfony\Framework\UserInterface;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\JobSecurity;
@@ -39,8 +40,11 @@ final class JobSecurityTest extends TestCase
             {
             }
 
-            public function isGranted(mixed $attribute, mixed $subject = null): bool
-            {
+            public function isGranted(
+                mixed $attribute,
+                mixed $subject = null,
+                AccessDecision|null $accessDecision = null,
+            ): bool {
                 return \in_array($attribute, $this->attributes, true)
                     && ($subject === null || $subject instanceof JobExecution);
             }

--- a/src/batch-symfony-framework/tests/UserInterface/TwigExtensionTest.php
+++ b/src/batch-symfony-framework/tests/UserInterface/TwigExtensionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yokai\Batch\Tests\Bridge\Symfony\Framework\UserInterface;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
@@ -44,8 +45,11 @@ TWIG
                         {
                         }
 
-                        public function isGranted(mixed $attribute, mixed $subject = null): bool
-                        {
+                        public function isGranted(
+                            mixed $attribute,
+                            mixed $subject = null,
+                            AccessDecision|null $accessDecision = null,
+                        ): bool {
                             return $this->granted;
                         }
                     },

--- a/src/batch-symfony-uid/tests/Factory/TimeBasedUuidJobExecutionIdGeneratorTest.php
+++ b/src/batch-symfony-uid/tests/Factory/TimeBasedUuidJobExecutionIdGeneratorTest.php
@@ -7,6 +7,7 @@ namespace Yokai\Batch\Tests\Bridge\Symfony\Uid\Factory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\Factory\UuidFactory;
 use Symfony\Component\Uid\UuidV6;
+use Symfony\Component\Uid\UuidV7;
 use Yokai\Batch\Bridge\Symfony\Uid\Factory\TimeBasedUuidJobExecutionIdGenerator;
 
 final class TimeBasedUuidJobExecutionIdGeneratorTest extends TestCase
@@ -15,6 +16,6 @@ final class TimeBasedUuidJobExecutionIdGeneratorTest extends TestCase
     {
         $id = (new TimeBasedUuidJobExecutionIdGenerator(new UuidFactory()))->generate();
 
-        self::assertTrue(UuidV6::isValid($id));
+        self::assertTrue(UuidV7::isValid($id) || UuidV6::isValid($id));
     }
 }


### PR DESCRIPTION
While reviewing #179, we noticed that recent changes in our dependencies caused some CI errors.
This PR fixes those compatibility issues to restore a green build.

**Changes:**
* **Symfony Compatibility:** Fix missing arguments and UUID generation to support the latest Symfony versions.
* **Dependencies:** Explicitly require `symfony/property-info` and `symfony/routing` versions to avoid conflicts.
* **Tooling:** Update Docker Compose versions and switch CI actions to use Symfony 7.4.
* **QA:** Clean up the PHPStan baseline by removing obsolete errors.