### PR TITLE
Rewrite pagination to render sliding pagination + Bundle configuration

### DIFF
--- a/docs/docs/bridges/symfony-framework.rst
+++ b/docs/docs/bridges/symfony-framework.rst
@@ -226,6 +226,21 @@ And create the class that will cover the templating:
    ``Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Templating\ConfigurableTemplating``
    that will cover both prefix and static variables at construction.
 
+Pagination
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``JobExecution`` list is paginated. You can configure the number of items per page and the size of
+the page window around the current page:
+
+.. code-block:: yaml
+
+    # config/packages/yokai_batch.yaml
+    yokai_batch:
+      ui:
+        pagination:
+          page_size: 20  # number of job executions per page (default: 20)
+          page_range: 2  # number of pages shown on each side of the current page (default: 2)
+
 Filtering
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/batch-doctrine-dbal/tests/DoctrineDBALJobExecutionStorageTest.php
+++ b/src/batch-doctrine-dbal/tests/DoctrineDBALJobExecutionStorageTest.php
@@ -408,6 +408,24 @@ final class DoctrineDBALJobExecutionStorageTest extends DoctrineDBALTestCase
         ];
     }
 
+    public function testCountIgnoresLimit(): void
+    {
+        $storage = $this->createStorage();
+        $storage->setup();
+        $this->loadFixtures($storage);
+
+        // Fixtures contain 4 executions in total.
+        // With limit(2, 0), query() must return 2 results while count() must return 4.
+        $query = (new QueryBuilder())->limit(2, 0)->getQuery();
+
+        $results = [];
+        foreach ($storage->query($query) as $execution) {
+            $results[] = $execution;
+        }
+        self::assertCount(2, $results);
+        self::assertSame(4, $storage->count($query));
+    }
+
     public static function assertExecutionIds(array $ids, iterable $executions): void
     {
         $actualIds = [];

--- a/src/batch-symfony-framework/src/DependencyInjection/Configuration.php
+++ b/src/batch-symfony-framework/src/DependencyInjection/Configuration.php
@@ -59,6 +59,10 @@ use Yokai\Batch\Serializer\JsonJobExecutionSerializer;
  *          service: string|null,
  *          base_template: string|null,
  *      },
+ *      pagination: array{
+ *          page_size: int,
+ *          page_range: int,
+ *      },
  *  }
  */
 final class Configuration implements ConfigurationInterface
@@ -283,6 +287,19 @@ final class Configuration implements ConfigurationInterface
                                     ->defaultValue('IS_AUTHENTICATED')
                                 ->end()
                             ->end()
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('pagination')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->integerNode('page_size')
+                            ->defaultValue(20)
+                            ->min(1)
+                        ->end()
+                        ->integerNode('page_range')
+                            ->defaultValue(2)
+                            ->min(1)
                         ->end()
                     ->end()
                 ->end()

--- a/src/batch-symfony-framework/src/DependencyInjection/YokaiBatchExtension.php
+++ b/src/batch-symfony-framework/src/DependencyInjection/YokaiBatchExtension.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Yokai\Batch\Bridge\Doctrine\DBAL\DoctrineDBALJobExecutionStorage;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Form\JobFilterType;
+use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\PaginationConfiguration;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Templating\ConfigurableTemplating;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Templating\SonataAdminTemplating;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Templating\TemplatingInterface;
@@ -222,5 +223,10 @@ final class YokaiBatchExtension extends Extension
                 ->addArgument(['base_template' => $templating['base_template']]);
             $container->setAlias(TemplatingInterface::class, 'yokai_batch.ui.templating');
         }
+
+        $pagination = $config['pagination'];
+        $container->register(PaginationConfiguration::class)
+            ->addArgument($pagination['page_size'])
+            ->addArgument($pagination['page_range']);
     }
 }

--- a/src/batch-symfony-framework/src/Resources/services/ui.php
+++ b/src/batch-symfony-framework/src/Resources/services/ui.php
@@ -9,6 +9,7 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Twig\Environment;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Controller\JobController;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\JobSecurity;
+use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\PaginationConfiguration;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Templating\TemplatingInterface;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\TwigExtension;
 use Yokai\Batch\Storage\JobExecutionStorageInterface;
@@ -23,6 +24,7 @@ return static function (ContainerConfigurator $container): void {
                 service(JobSecurity::class),
                 service(Environment::class),
                 service(TemplatingInterface::class),
+                service(PaginationConfiguration::class),
             ])
             ->tag('controller.service_arguments')
 

--- a/src/batch-symfony-framework/src/Resources/views/bootstrap4/list.html.twig
+++ b/src/batch-symfony-framework/src/Resources/views/bootstrap4/list.html.twig
@@ -112,8 +112,8 @@
 
 {% block pagination %}
     {% if pagination.total_pages > 1 %}
-        {% set window_start = max(1, pagination.current - 2) %}
-        {% set window_end = min(pagination.total_pages, pagination.current + 2) %}
+        {% set window_start = max(1, pagination.current - pagination.page_range) %}
+        {% set window_end = min(pagination.total_pages, pagination.current + pagination.page_range) %}
         <ul class="pagination">
             {% if pagination.prev.enabled %}
                 <li class="page-item">

--- a/src/batch-symfony-framework/src/Resources/views/bootstrap4/list.html.twig
+++ b/src/batch-symfony-framework/src/Resources/views/bootstrap4/list.html.twig
@@ -111,22 +111,13 @@
 {% endblock %}
 
 {% block pagination %}
-    {% if executions|length > 0 and (pagination.prev.enabled or pagination.next.enabled) %}
+    {% if pagination.total_pages > 1 %}
+        {% set window_start = max(1, pagination.current - 2) %}
+        {% set window_end = min(pagination.total_pages, pagination.current + 2) %}
         <ul class="pagination">
-            {% if pagination.current > 2 %}
-                <li class="page-item">
-                    <a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): 1 }) }}"
-                       class="page-link"
-                       title="{{ 'job.action.pagination_first'|trans }}">
-                        <span aria-hidden="true">&laquo;</span>
-                        <span class="sr-only">{{ 'job.action.pagination_first'|trans }}</span>
-                    </a>
-                </li>
-            {% endif %}
-
             {% if pagination.prev.enabled %}
                 <li class="page-item">
-                    <a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): pagination.prev.value }) }}"
+                    <a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): pagination.prev.value, (sort.parameter): sort.current }) }}"
                        class="page-link"
                        title="{{ 'job.action.pagination_prev'|trans }}">
                         <span aria-hidden="true">&lsaquo;</span>
@@ -135,9 +126,36 @@
                 </li>
             {% endif %}
 
+            {% if window_start > 1 %}
+                <li class="page-item">
+                    <a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): 1, (sort.parameter): sort.current }) }}"
+                       class="page-link">1</a>
+                </li>
+                {% if window_start > 2 %}
+                    <li class="page-item disabled"><span class="page-link">…</span></li>
+                {% endif %}
+            {% endif %}
+
+            {% for p in range(window_start, window_end) %}
+                <li class="page-item {% if p == pagination.current %}active{% endif %}">
+                    <a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): p, (sort.parameter): sort.current }) }}"
+                       class="page-link">{{ p }}</a>
+                </li>
+            {% endfor %}
+
+            {% if window_end < pagination.total_pages %}
+                {% if window_end < pagination.total_pages - 1 %}
+                    <li class="page-item disabled"><span class="page-link">…</span></li>
+                {% endif %}
+                <li class="page-item">
+                    <a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): pagination.total_pages, (sort.parameter): sort.current }) }}"
+                       class="page-link">{{ pagination.total_pages }}</a>
+                </li>
+            {% endif %}
+
             {% if pagination.next.enabled %}
                 <li class="page-item">
-                    <a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): pagination.next.value }) }}"
+                    <a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): pagination.next.value, (sort.parameter): sort.current }) }}"
                        class="page-link"
                        title="{{ 'job.action.pagination_next'|trans }}">
                         <span aria-hidden="true">&rsaquo;</span>

--- a/src/batch-symfony-framework/src/Resources/views/sonata/list.html.twig
+++ b/src/batch-symfony-framework/src/Resources/views/sonata/list.html.twig
@@ -119,8 +119,8 @@
         {% if pagination.total_pages > 1 %}
             <div class="box-footer">
                 <div class="text-center">
-                    {% set window_start = max(1, pagination.current - 2) %}
-                    {% set window_end = min(pagination.total_pages, pagination.current + 2) %}
+                    {% set window_start = max(1, pagination.current - pagination.page_range) %}
+                    {% set window_end = min(pagination.total_pages, pagination.current + pagination.page_range) %}
                     <ul class="pagination">
                         {% if pagination.prev.enabled %}
                             <li>

--- a/src/batch-symfony-framework/src/Resources/views/sonata/list.html.twig
+++ b/src/batch-symfony-framework/src/Resources/views/sonata/list.html.twig
@@ -116,27 +116,38 @@
                 </table>
             </div>
         </div>
-        {% if executions|length > 0 and (pagination.prev.enabled or pagination.next.enabled) %}
+        {% if pagination.total_pages > 1 %}
             <div class="box-footer">
                 <div class="text-center">
+                    {% set window_start = max(1, pagination.current - 2) %}
+                    {% set window_end = min(pagination.total_pages, pagination.current + 2) %}
                     <ul class="pagination">
-                        {% if pagination.current > 2 %}
-                            <li>
-                                <a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): 1 }) }}"
-                                   title="{{ 'link_first_pager'|trans({}, 'SonataAdminBundle') }}">&laquo;</a>
-                            </li>
-                        {% endif %}
-
                         {% if pagination.prev.enabled %}
                             <li>
-                                <a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): pagination.prev.value }) }}"
+                                <a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): pagination.prev.value, (sort.parameter): sort.current }) }}"
                                    title="{{ 'link_previous_pager'|trans({}, 'SonataAdminBundle') }}">&lsaquo;</a>
                             </li>
                         {% endif %}
 
+                        {% if window_start > 1 %}
+                            <li><a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): 1, (sort.parameter): sort.current }) }}">1</a></li>
+                            {% if window_start > 2 %}<li class="disabled"><span>…</span></li>{% endif %}
+                        {% endif %}
+
+                        {% for p in range(window_start, window_end) %}
+                            <li class="{% if p == pagination.current %}active{% endif %}">
+                                <a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): p, (sort.parameter): sort.current }) }}">{{ p }}</a>
+                            </li>
+                        {% endfor %}
+
+                        {% if window_end < pagination.total_pages %}
+                            {% if window_end < pagination.total_pages - 1 %}<li class="disabled"><span>…</span></li>{% endif %}
+                            <li><a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): pagination.total_pages, (sort.parameter): sort.current }) }}">{{ pagination.total_pages }}</a></li>
+                        {% endif %}
+
                         {% if pagination.next.enabled %}
                             <li>
-                                <a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): pagination.next.value }) }}"
+                                <a href="{{ path('yokai_batch.job_list', { filter: parameters, (pagination.parameter): pagination.next.value, (sort.parameter): sort.current }) }}"
                                    title="{{ 'link_next_pager'|trans({}, 'SonataAdminBundle') }}">&rsaquo;</a>
                             </li>
                         {% endif %}

--- a/src/batch-symfony-framework/src/UserInterface/Controller/JobController.php
+++ b/src/batch-symfony-framework/src/UserInterface/Controller/JobController.php
@@ -76,6 +76,10 @@ final readonly class JobController
             }
         }
 
+        // count total matching executions before applying limit (for pagination)
+        $total = $this->jobExecutionStorage->count($query->getQuery());
+        $totalPages = (int)\ceil($total / self::LIMIT);
+
         try {
             $query->limit(self::LIMIT, self::LIMIT * ($page - 1));
             $query->sort($sort);
@@ -109,14 +113,17 @@ final readonly class JobController
         $pagination = [
             'parameter' => 'page',
             'per_page' => self::LIMIT,
+            'total' => $total,
+            'total_pages' => $totalPages,
             'results' => \count($executions),
             'current' => $page,
             'is' => [
                 'first' => $page === 1,
-                'last' => \count($executions) !== self::LIMIT,
+                'last' => $page >= $totalPages || $totalPages === 0,
             ],
-            'prev' => ['enabled' => $page !== 1, 'value' => $page - 1],
-            'next' => ['enabled' => \count($executions) === self::LIMIT, 'value' => $page + 1],
+            'prev' => ['enabled' => $page > 1, 'value' => $page - 1],
+            'next' => ['enabled' => $page < $totalPages, 'value' => $page + 1],
+            'last' => ['enabled' => $page < $totalPages, 'value' => $totalPages],
         ];
 
         return new Response(

--- a/src/batch-symfony-framework/src/UserInterface/Controller/JobController.php
+++ b/src/batch-symfony-framework/src/UserInterface/Controller/JobController.php
@@ -15,6 +15,7 @@ use Twig\Environment;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Form\JobFilter;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Form\JobFilterType;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\JobSecurity;
+use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\PaginationConfiguration;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Templating\TemplatingInterface;
 use Yokai\Batch\Exception\JobExecutionNotFoundException;
 use Yokai\Batch\JobExecution;
@@ -27,14 +28,13 @@ use Yokai\Batch\Storage\QueryBuilder;
  */
 final readonly class JobController
 {
-    private const LIMIT = 20;
-
     public function __construct(
         private QueryableJobExecutionStorageInterface $jobExecutionStorage,
         private null|FormFactoryInterface $formFactory,
         private JobSecurity $security,
         private Environment $twig,
         private TemplatingInterface $templating,
+        private PaginationConfiguration $paginationConfiguration,
     ) {
     }
 
@@ -78,10 +78,11 @@ final readonly class JobController
 
         // count total matching executions before applying limit (for pagination)
         $total = $this->jobExecutionStorage->count($query->getQuery());
-        $totalPages = (int)\ceil($total / self::LIMIT);
+        $pageSize = $this->paginationConfiguration->pageSize;
+        $totalPages = (int)\ceil($total / $pageSize);
 
         try {
-            $query->limit(self::LIMIT, self::LIMIT * ($page - 1));
+            $query->limit($pageSize, $pageSize * ($page - 1));
             $query->sort($sort);
         } catch (Throwable $exception) {
             throw new BadRequestHttpException(previous: $exception);
@@ -112,7 +113,8 @@ final readonly class JobController
         // prepare pagination variable for view
         $pagination = [
             'parameter' => 'page',
-            'per_page' => self::LIMIT,
+            'per_page' => $pageSize,
+            'page_range' => $this->paginationConfiguration->pageRange,
             'total' => $total,
             'total_pages' => $totalPages,
             'results' => \count($executions),

--- a/src/batch-symfony-framework/src/UserInterface/PaginationConfiguration.php
+++ b/src/batch-symfony-framework/src/UserInterface/PaginationConfiguration.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yokai\Batch\Bridge\Symfony\Framework\UserInterface;
+
+/**
+ * Holds UI pagination settings configured via the bundle.
+ */
+final readonly class PaginationConfiguration
+{
+    public function __construct(
+        public int $pageSize,
+        public int $pageRange,
+    ) {
+    }
+}

--- a/src/batch-symfony-framework/tests/UserInterface/Controller/JobControllerTest.php
+++ b/src/batch-symfony-framework/tests/UserInterface/Controller/JobControllerTest.php
@@ -110,7 +110,7 @@ final class JobControllerTest extends TestCase
                         $templating,
                         $status,
                         20,
-                        1,
+                        3,
                     ];
                     yield [
                         fn() => self::fixtures(30),
@@ -120,7 +120,7 @@ final class JobControllerTest extends TestCase
                         $templating,
                         $status,
                         20,
-                        1,
+                        3,
                     ];
                     yield [
                         fn() => null,
@@ -138,7 +138,7 @@ final class JobControllerTest extends TestCase
                         $templating,
                         $status,
                         10,
-                        1,
+                        3,
                     ];
 
                     // filtering is only possible when symfony/form is installed
@@ -182,7 +182,7 @@ final class JobControllerTest extends TestCase
                             $templating,
                             $status,
                             10,
-                            1,
+                            3,
                         ];
                     }
                 }

--- a/src/batch-symfony-framework/tests/UserInterface/Controller/JobControllerTest.php
+++ b/src/batch-symfony-framework/tests/UserInterface/Controller/JobControllerTest.php
@@ -40,6 +40,7 @@ use Yokai\Batch\BatchStatus;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Controller\JobController;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Form\JobFilterType;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\JobSecurity;
+use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\PaginationConfiguration;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Templating\ConfigurableTemplating;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\Templating\TemplatingInterface;
 use Yokai\Batch\Bridge\Symfony\Framework\UserInterface\TwigExtension;
@@ -500,7 +501,14 @@ final class JobControllerTest extends TestCase
             ),
         ]));
 
-        return new JobController(self::$storage, $formFactory, $security, $twig, $templating);
+        return new JobController(
+            self::$storage,
+            $formFactory,
+            $security,
+            $twig,
+            $templating,
+            new PaginationConfiguration(20, 2),
+        );
     }
 
     private static function fixtures(int $count, array $attributes = []): void

--- a/src/batch/src/Storage/FilesystemJobExecutionStorage.php
+++ b/src/batch/src/Storage/FilesystemJobExecutionStorage.php
@@ -91,7 +91,36 @@ final readonly class FilesystemJobExecutionStorage implements QueryableJobExecut
 
     public function query(Query $query): iterable
     {
-        $candidates = [];
+        $jobExecutions = $this->rawQuery($query);
+
+        $order = match ($query->sort()) {
+            Query::SORT_BY_START_ASC => static fn(JobExecution $left, JobExecution $right): int => $left->getStartTime() <=> $right->getStartTime(),
+            Query::SORT_BY_START_DESC => static fn(JobExecution $left, JobExecution $right): int => $right->getStartTime() <=> $left->getStartTime(),
+            Query::SORT_BY_END_ASC => static fn(JobExecution $left, JobExecution $right): int => $left->getEndTime() <=> $right->getEndTime(),
+            Query::SORT_BY_END_DESC => static fn(JobExecution $left, JobExecution $right): int => $right->getEndTime() <=> $left->getEndTime(),
+            default => null,
+        };
+
+        if ($order) {
+            \uasort($jobExecutions, $order);
+        }
+
+        return \array_slice($jobExecutions, $query->offset(), $query->limit());
+    }
+
+    public function count(Query $query): int
+    {
+        $jobExecutions = $this->rawQuery($query);
+
+        return \count($jobExecutions);
+    }
+
+    /**
+     * @return list<JobExecution>
+     */
+    private function rawQuery(Query $query): array
+    {
+        $jobExecutions = [];
         $glob = new \GlobIterator(
             \implode(DIRECTORY_SEPARATOR, [$this->directory, '**', '*']) . '.' . $this->serializer->extension(),
         );
@@ -143,30 +172,10 @@ final readonly class FilesystemJobExecutionStorage implements QueryableJobExecut
                 continue;
             }
 
-            $candidates[] = $execution;
+            $jobExecutions[] = $execution;
         }
 
-        $order = match ($query->sort()) {
-            Query::SORT_BY_START_ASC => static fn(JobExecution $left, JobExecution $right): int => $left->getStartTime() <=> $right->getStartTime(),
-            Query::SORT_BY_START_DESC => static fn(JobExecution $left, JobExecution $right): int => $right->getStartTime() <=> $left->getStartTime(),
-            Query::SORT_BY_END_ASC => static fn(JobExecution $left, JobExecution $right): int => $left->getEndTime() <=> $right->getEndTime(),
-            Query::SORT_BY_END_DESC => static fn(JobExecution $left, JobExecution $right): int => $right->getEndTime() <=> $left->getEndTime(),
-            default => null,
-        };
-
-        if ($order) {
-            \uasort($candidates, $order);
-        }
-
-        return \array_slice($candidates, $query->offset(), $query->limit());
-    }
-
-    public function count(Query $query): int
-    {
-        /** @var JobExecution[] $result */
-        $result = $this->query($query);
-
-        return \count($result);
+        return $jobExecutions;
     }
 
     private function buildFilePath(string $jobName, string $executionId): string

--- a/src/batch/src/Storage/QueryableJobExecutionStorageInterface.php
+++ b/src/batch/src/Storage/QueryableJobExecutionStorageInterface.php
@@ -20,6 +20,7 @@ interface QueryableJobExecutionStorageInterface extends ListableJobExecutionStor
 
     /**
      * Execute query against stored job executions, and return count result.
+     * Note: limit and offset from the query are ignored — all matching executions are counted.
      */
     public function count(Query $query): int;
 }

--- a/src/batch/tests/Storage/FilesystemJobExecutionStorageTest.php
+++ b/src/batch/tests/Storage/FilesystemJobExecutionStorageTest.php
@@ -283,6 +283,25 @@ final class FilesystemJobExecutionStorageTest extends TestCase
         ];
     }
 
+    public function testCountIgnoresLimit(): void
+    {
+        $storage = $this->createStorage(
+            __DIR__ . '/fixtures/filesystem-job-execution',
+            new JsonJobExecutionSerializer(),
+        );
+
+        // Fixtures contain 5 executions in total.
+        // With limit(2, 0), query() must return 2 results while count() must return 5.
+        $query = (new QueryBuilder())->limit(2, 0)->getQuery();
+
+        $results = [];
+        foreach ($storage->query($query) as $execution) {
+            $results[] = $execution;
+        }
+        self::assertCount(2, $results);
+        self::assertSame(5, $storage->count($query));
+    }
+
     public function testRetrieveFilePathNotFound(): void
     {
         $this->expectException(JobExecutionNotFoundException::class);


### PR DESCRIPTION
## Improve job list pagination UI

### Summary

The job list pagination was limited to basic First/Previous/Next buttons with no indication of the current position or total pages. This PR replaces it with a proper numbered pagination, makes it aware of the total record count, and exposes the key settings as bundle configuration.

---

### Changes

#### Controller — `JobController`

- Added a `count()` call on the storage (before applying `limit`) to retrieve the total number of matching executions
- Replaced the hardcoded `LIMIT = 20` constant with a configurable `PaginationConfiguration` service
- Extended the `pagination` template variable with `total`, `total_pages`, `page_range`, and a `last` entry (symmetric with the existing `prev`/`next`)
- Fixed `next.enabled` logic: was `count($executions) === LIMIT` (fragile off-by-one on last page), now `$page < $totalPages`
- Fixed pagination links: now preserve the active sort parameter across page changes (was missing)

#### Templates — `bootstrap4/list.html.twig` and `sonata/list.html.twig`

Replaced the three-button pagination (First / Previous / Next) with a sliding window pagination:

- Always shows the **Previous** `‹` arrow when not on page 1
- Always shows the **Next** `›` arrow when not on the last page
- Renders **numbered page links** in a configurable window around the current page (default ±2)
- Inserts **ellipsis** `…` when the window does not start at page 1 or does not reach the last page
- Always shows **page 1** and **last page** as anchors outside the window
- Hides the pagination block entirely when there is only one page

Example rendering for page 10 of 15:
```
‹  …  8  9  [10]  11  12  …  15  ›
```

#### Bundle configuration

Added a `pagination` subsection under `ui` in the bundle configuration tree:

```yaml
yokai_batch:
  ui:
    pagination:
      page_size: 20   # number of executions per page (default: 20)
      page_range: 2   # pages shown on each side of the current page (default: 2)
```

Both values are validated (minimum 1) and injected into a new `PaginationConfiguration` readonly DTO, which is registered as the `yokai_batch.ui.pagination` service and passed to `JobController`.

#### Storage — regression tests for `count()` ignoring limit

`QueryBuilder` carries a default limit of `10`. Both storage implementations must ignore this limit in their `count()` method; the existing tests did not exercise this because their fixture sets were smaller than the default limit.

Added `testCountIgnoresLimit()` to:
- `FilesystemJobExecutionStorageTest` — asserts `count()` returns 5 (total fixtures) while `query()` returns 2 (limited)
- `DoctrineDBALJobExecutionStorageTest` — asserts `count()` returns 4 (total fixtures) while `query()` returns 2 (limited)
