### PR TITLE
Fixed PHPUnit 13 Deprecations

### DIFF
--- a/src/batch/tests/Storage/FilesystemJobExecutionStorageTest.php
+++ b/src/batch/tests/Storage/FilesystemJobExecutionStorageTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yokai\Batch\Tests\Storage;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Yokai\Batch\BatchStatus;
 use Yokai\Batch\Exception\CannotRemoveJobExecutionException;
@@ -26,7 +26,7 @@ final class FilesystemJobExecutionStorageTest extends TestCase
     private const STORAGE_DIR = ARTIFACT_DIR . '/filesystem-storage';
     private const READONLY_STORAGE_DIR = ARTIFACT_DIR . '/filesystem-storage-readonly';
 
-    private Stub&JobExecutionSerializerInterface $serializer;
+    private MockObject&JobExecutionSerializerInterface $serializer;
 
     public static function setUpBeforeClass(): void
     {
@@ -39,8 +39,9 @@ final class FilesystemJobExecutionStorageTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->serializer = $this->createStub(JobExecutionSerializerInterface::class);
+        $this->serializer = $this->createMock(JobExecutionSerializerInterface::class);
         $this->serializer->method('extension')
+            ->with()
             ->willReturn('txt');
     }
 


### PR DESCRIPTION
https://github.com/sebastianbergmann/phpunit/issues/6504

**From**

```
.............................................................   61 / 1149 (  5%)
.............................................................  122 / 1149 ( 10%)
.............................................................  183 / 1149 ( 15%)
.............................................................  244 / 1149 ( 21%)
.............................................................  305 / 1149 ( 26%)
.............................................................  366 / 1149 ( 31%)
.............................................................  427 / 1149 ( 37%)
..................................DD.D...................D...  488 / 1149 ( 42%)
.............................................................  549 / 1149 ( 47%)
.............................................................  610 / 1149 ( 53%)
.............................................................  671 / 1149 ( 58%)
.............................................................  732 / 1149 ( 63%)
.............................................................  793 / 1149 ( 69%)
.............................................................  854 / 1149 ( 74%)
.............................................................  915 / 1149 ( 79%)
.............................................................  976 / 1149 ( 84%)
............................................................. 1037 / 1149 ( 90%)
............................................................. 1098 / 1149 ( 95%)
...................................................           1149 / 1149 (100%)

Time: 00:02.500, Memory: 48.00 MB

4 tests triggered 4 PHPUnit deprecations:

1) Yokai\Batch\Tests\Storage\FilesystemJobExecutionStorageTest::testStore
Using with*() on a test stub has no effect and is deprecated.
With PHPUnit 13, it will not be possible to use with() on a test stub.

/src/src/batch/tests/Storage/FilesystemJobExecutionStorageTest.php:57

2) Yokai\Batch\Tests\Storage\FilesystemJobExecutionStorageTest::testStoreFileNotWritable
Using with*() on a test stub has no effect and is deprecated.
With PHPUnit 13, it will not be possible to use with() on a test stub.

/src/src/batch/tests/Storage/FilesystemJobExecutionStorageTest.php:73

3) Yokai\Batch\Tests\Storage\FilesystemJobExecutionStorageTest::testRetrieve
Using with*() on a test stub has no effect and is deprecated.
With PHPUnit 13, it will not be possible to use with() on a test stub.

/src/src/batch/tests/Storage/FilesystemJobExecutionStorageTest.php:94

4) Yokai\Batch\Tests\Storage\FilesystemJobExecutionStorageTest::testRemove
Using with*() on a test stub has no effect and is deprecated.
With PHPUnit 13, it will not be possible to use with() on a test stub.

/src/src/batch/tests/Storage/FilesystemJobExecutionStorageTest.php:320

OK, but there were issues!
Tests: 1149, Assertions: 4193, PHPUnit Deprecations: 4.
```

**To**

```
.............................................................   61 / 1149 (  5%)
.............................................................  122 / 1149 ( 10%)
.............................................................  183 / 1149 ( 15%)
.............................................................  244 / 1149 ( 21%)
.............................................................  305 / 1149 ( 26%)
.............................................................  366 / 1149 ( 31%)
.............................................................  427 / 1149 ( 37%)
.............................................................  488 / 1149 ( 42%)
.............................................................  549 / 1149 ( 47%)
.............................................................  610 / 1149 ( 53%)
.............................................................  671 / 1149 ( 58%)
.............................................................  732 / 1149 ( 63%)
.............................................................  793 / 1149 ( 69%)
.............................................................  854 / 1149 ( 74%)
.............................................................  915 / 1149 ( 79%)
.............................................................  976 / 1149 ( 84%)
............................................................. 1037 / 1149 ( 90%)
............................................................. 1098 / 1149 ( 95%)
...................................................           1149 / 1149 (100%)

Time: 00:02.305, Memory: 48.00 MB

OK (1149 tests, 4193 assertions)
```