### PR TITLE
Fix FilterUniqueProcessor state leak and endTime filter wrong column

### DIFF
--- a/src/batch-doctrine-dbal/src/DoctrineDBALJobExecutionStorage.php
+++ b/src/batch-doctrine-dbal/src/DoctrineDBALJobExecutionStorage.php
@@ -395,7 +395,7 @@ final class DoctrineDBALJobExecutionStorage implements
         }
 
         if ($query->endTime() !== null) {
-            $qb->andWhere($qb->expr()->isNotNull('start_time'));
+            $qb->andWhere($qb->expr()->isNotNull('end_time'));
         }
         $endDateFrom = $query->endTime()?->getFrom();
         if ($endDateFrom !== null) {

--- a/src/batch/src/Job/Item/Processor/FilterUniqueProcessor.php
+++ b/src/batch/src/Job/Item/Processor/FilterUniqueProcessor.php
@@ -6,6 +6,7 @@ namespace Yokai\Batch\Job\Item\Processor;
 
 use Closure;
 use Yokai\Batch\Job\Item\Exception\SkipItemException;
+use Yokai\Batch\Job\Item\InitializableInterface;
 use Yokai\Batch\Job\Item\ItemProcessorInterface;
 
 /**
@@ -15,7 +16,7 @@ use Yokai\Batch\Job\Item\ItemProcessorInterface;
  * it will use a {@see Closure} that will be called for each item
  * and that will be responsible for extracting an identifier from the item.
  */
-final class FilterUniqueProcessor implements ItemProcessorInterface
+final class FilterUniqueProcessor implements ItemProcessorInterface, InitializableInterface
 {
     /**
      * @var array<string, bool>
@@ -58,6 +59,11 @@ final class FilterUniqueProcessor implements ItemProcessorInterface
     public static function withGetter(string $getter): self
     {
         return new self(fn(object $item) => $item->$getter());
+    }
+
+    public function initialize(): void
+    {
+        $this->encountered = [];
     }
 
     public function process(mixed $item): mixed

--- a/src/batch/tests/Job/Item/Processor/FilterUniqueProcessorTest.php
+++ b/src/batch/tests/Job/Item/Processor/FilterUniqueProcessorTest.php
@@ -19,16 +19,21 @@ final class FilterUniqueProcessorTest extends TestCase
         /** @var FilterUniqueProcessor $processor */
         $processor = $factory();
 
-        $actual = [];
-        foreach ($items as $item) {
-            try {
-                $actual[] = $processor->process($item);
-            } catch (SkipItemException) {
-                //the item have be filtered and not won't be added to $actual
-            }
-        }
+        // test is done twice to prove initialize method resets state
+        foreach ([1, 2] as $unused) {
+            $processor->initialize();
 
-        self::assertSame($expected, $actual);
+            $actual = [];
+            foreach ($items as $item) {
+                try {
+                    $actual[] = $processor->process($item);
+                } catch (SkipItemException) {
+                    //the item have be filtered and not won't be added to $actual
+                }
+            }
+
+            self::assertSame($expected, $actual);
+        }
     }
 
     public static function provider(): Generator


### PR DESCRIPTION
## Summary

- **`FilterUniqueProcessor` state leak between job runs**: The processor was not implementing `InitializableInterface`, so its internal `$encountered` set was never reset between executions. When a job was run multiple times in the same process (e.g. in tests or long-running workers), previously seen items would incorrectly be filtered out. The fix implements `InitializableInterface::initialize()` to clear the set at the start of each job run.

- **`endTime` filter querying wrong column**: In `DoctrineDBALJobExecutionStorage`, the `endTime` presence filter was using `isNotNull('start_time')` instead of `isNotNull('end_time')` — a copy-paste mistake. As a result, filtering job executions by `endTime` would silently fall back to filtering by `start_time`, returning wrong results.

